### PR TITLE
Support for environment variable BOOST_ROOT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,9 @@ project(Ignite.C++ VERSION 2.13.0.58917)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/modules/code-coverage.cmake")
 add_code_coverage_all_targets(EXCLUDE odbc-test)
-
+if (NOT "$ENV{BOOST_ROOT}" STREQUAL "")
+    set(BOOST_ROOT "$ENV{BOOST_ROOT}")
+endif()
 set(CMAKE_CXX_STANDARD 98)
 
 set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
### Summary
Adding ability to specify boost version to use through environment variables

### Description
Setting BOOST_ROOT in root CMakeList file.

### Related Issue
https://bitquill.atlassian.net/browse/AD-509

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
@garya-bitquill
<!-- Any additional reviewers -->
