### PR TITLE
Update checks.yml not to fail the build

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,4 @@ jobs:
     - uses: actions/checkout@v2
     - uses: ZedThree/clang-tidy-review@v0.7.0
       id: review
-    - if: steps.review.outputs.total_comments > 0
-      run: exit 1
- 
+      


### PR DESCRIPTION
## Summary
clang-tidy checks should not fail the build.

## Description
Github action with clang-tidy will be triggered on each PR

## Related Issue
N/A

Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
@garya-bitquill