### PR TITLE
[AD-521] get SSH port from JDBC

### DIFF
--- a/src/odbc/include/ignite/odbc/jni/java.h
+++ b/src/odbc/include/ignite/odbc/jni/java.h
@@ -258,6 +258,8 @@ namespace ignite {
                   jmethodID m_DocumentDbConnectionPropertiesGetPropertiesFromConnectionString;
 
                   jclass c_DocumentDbConnection;
+                  jmethodID m_DocumentDbConnectionGetSshLocalPort;
+                  jmethodID m_DocumentDbConnectionIsSshTunnelActive;
                   jmethodID m_DocumentDbConnectionInit;
                   jmethodID m_DocumentDbClose;
 
@@ -447,6 +449,9 @@ namespace ignite {
                   bool DriverManagerGetConnection(const char* connectionString, SharedPointer< GlobalJObject >& connection, JniErrorInfo& errInfo);
                   void ConnectionClose(const SharedPointer< GlobalJObject >& connection, JniErrorInfo& errInfo);
                   bool ConnectionGetMetaData(const SharedPointer< GlobalJObject >& connection, SharedPointer< GlobalJObject>& databaseMetaData, JniErrorInfo& errInfo);
+
+                  bool DocumentDbConnectionIsSshTunnelActive(const SharedPointer< GlobalJObject >& connection, bool& isActive, JniErrorInfo& errInfo);
+                  bool DocumentDbConnectionGetSshLocalPort(const SharedPointer< GlobalJObject >& connection, int32_t& result, JniErrorInfo& errInfo);
 
                   bool DatabaseMetaDataGetTables(
                       const SharedPointer< GlobalJObject >& databaseMetaData,
@@ -699,5 +704,5 @@ namespace ignite {
         }  // namespace jni
     }  // namespace odbc
 }  // namespace ignite
-
 #endif //_IGNITE_ODBC_JNI_JAVA
+


### PR DESCRIPTION
### Summary

Set up jni function call to get SSH port from JDBC

### Description

This branch is based on birschick-bq/ad-427/metadata. 3 files are changed on top of this branch: java.h, java.cpp, java_test.cpp.
The checks should pass when the new version of Jar is released and looked into.

Plans (in order, but it is not strict order): 
- [x] change getSshLocalPort from private to public
- [x] define function constants
- - [x] for Java class
- - [x] for Java getSshLocalPort function
- [x] save the integer (port number) returned from JDBC
- [x] work on wrapper code with Bruce
- [x] write test for the code

### Related Issue

https://bitquill.atlassian.net/jira/software/c/projects/AD/boards/47?modal=detail&selectedIssue=AD-521

Publicly expose the local port use when internal SSH tunnel is created. 

Setup call on ODBC side.

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
<!-- Any additional reviewers -->
