### PR TITLE
[AD-589] Get schema metadata from JDBC

### DIFF
--- a/src/odbc-test/src/java_test.cpp
+++ b/src/odbc-test/src/java_test.cpp
@@ -282,6 +282,66 @@ BOOST_AUTO_TEST_CASE(TestDocumentDbConnectionGetSshTunnelPortSshTunnelNotActive,
     BOOST_CHECK_EQUAL(port, 0);
 }
 
+BOOST_AUTO_TEST_CASE(TestDocumentDbConnectionGetDatabaseMetadata) {
+    PrepareContext();
+    BOOST_REQUIRE(_ctx.Get() != nullptr);
+
+    // get Driver manager connection
+    JniErrorInfo errInfo;
+    SharedPointer< GlobalJObject > connection;
+    bool success = _ctx.Get()->DriverManagerGetConnection(
+        _jdbcConnectionString.c_str(), connection, errInfo);
+    if (!success || errInfo.code != odbc::java::IGNITE_JNI_ERR_SUCCESS) {
+        BOOST_FAIL(errInfo.errMsg);
+    }
+    BOOST_REQUIRE(connection.Get());
+    AutoCloseConnection autoCloseConnection(_ctx, connection);
+
+    // get metadata
+    SharedPointer< GlobalJObject > databaseMetadata;
+    if (!_ctx.Get()->DocumentDbConnectionGetDatabaseMetadata(
+            connection, databaseMetadata,
+                                           errInfo)) {
+        BOOST_FAIL(errInfo.errMsg);
+    }
+    BOOST_REQUIRE(databaseMetadata.Get());
+}
+
+BOOST_AUTO_TEST_CASE(TestDocumentDbDatabaseSchemaMetadataGetSchemaName) { 
+    PrepareContext();
+    BOOST_REQUIRE(_ctx.Get() != nullptr);
+
+    // get Driver manager connection
+    JniErrorInfo errInfo;
+    SharedPointer< GlobalJObject > connection;
+    bool success = _ctx.Get()->DriverManagerGetConnection(
+        _jdbcConnectionString.c_str(), connection, errInfo);
+    if (!success || errInfo.code != odbc::java::IGNITE_JNI_ERR_SUCCESS) {
+        BOOST_FAIL(errInfo.errMsg);
+    }
+    BOOST_REQUIRE(connection.Get());
+    AutoCloseConnection autoCloseConnection(_ctx, connection);
+
+    // get metadata
+    SharedPointer< GlobalJObject > databaseMetadata;
+    if (!_ctx.Get()->DocumentDbConnectionGetDatabaseMetadata(
+            connection, databaseMetadata, errInfo)) {
+        BOOST_FAIL(errInfo.errMsg);
+    }
+    BOOST_REQUIRE(databaseMetadata.Get());
+
+    std::string schemaName;
+    bool wasNull;
+    success = _ctx.Get()->DocumentDbDatabaseSchemaMetadataGetSchemaName(
+        databaseMetadata, schemaName, wasNull, errInfo); 
+    if (!success || errInfo.code != odbc::java::IGNITE_JNI_ERR_SUCCESS) {
+        BOOST_FAIL(errInfo.errMsg);
+    }
+
+    BOOST_CHECK(!wasNull);
+    BOOST_CHECK_EQUAL(schemaName, "_default");
+}
+
 BOOST_AUTO_TEST_CASE(TestConnectionGetMetaData) {
     PrepareContext();
     BOOST_REQUIRE(_ctx.Get() != nullptr);

--- a/src/odbc/include/ignite/odbc/jni/java.h
+++ b/src/odbc/include/ignite/odbc/jni/java.h
@@ -260,8 +260,12 @@ namespace ignite {
                   jclass c_DocumentDbConnection;
                   jmethodID m_DocumentDbConnectionGetSshLocalPort;
                   jmethodID m_DocumentDbConnectionIsSshTunnelActive;
+                  jmethodID m_DocumentDbConnectionGetDatabaseMetadata;
                   jmethodID m_DocumentDbConnectionInit;
                   jmethodID m_DocumentDbClose;
+
+                  jclass c_DocumentDbDatabaseSchemaMetadata;
+                  jmethodID m_DocumentDbDatabaseSchemaMetadataGetSchemaName;
 
                   jclass c_DriverManager;
                   jmethodID m_DriverManagerGetConnection;
@@ -452,6 +456,9 @@ namespace ignite {
 
                   bool DocumentDbConnectionIsSshTunnelActive(const SharedPointer< GlobalJObject >& connection, bool& isActive, JniErrorInfo& errInfo);
                   bool DocumentDbConnectionGetSshLocalPort(const SharedPointer< GlobalJObject >& connection, int32_t& result, JniErrorInfo& errInfo);
+                  bool DocumentDbConnectionGetDatabaseMetadata(const SharedPointer< GlobalJObject >& connection, SharedPointer< GlobalJObject >& metadata, JniErrorInfo& errInfo);
+
+                  bool DocumentDbDatabaseSchemaMetadataGetSchemaName(const SharedPointer< GlobalJObject >& databaseMetadata, std::string& value, bool& wasNull, JniErrorInfo& errInfo);
 
                   bool DatabaseMetaDataGetTables(
                       const SharedPointer< GlobalJObject >& databaseMetaData,

--- a/src/odbc/src/jni/java.cpp
+++ b/src/odbc/src/jni/java.cpp
@@ -283,6 +283,14 @@ namespace ignite
                     JniMethod("getSshLocalPort", "()I", false);
                 JniMethod const M_DOCUMENTDB_CONNECTION_IS_SSH_TUNNEL_ACTIVE =
                     JniMethod("isSshTunnelActive", "()Z", false);
+                JniMethod const M_DOCUMENTDB_CONNECTION_GET_DATABASE_METADATA =
+                    JniMethod("getDatabaseMetadata", "()Lsoftware/amazon/documentdb/jdbc/metadata/DocumentDbDatabaseSchemaMetadata;", false); 
+
+                const char* const C_DOCUMENTDB_DATABASE_SCHEMA_METADATA =
+                    "software/amazon/documentdb/jdbc/metadata/DocumentDbDatabaseSchemaMetadata";
+                JniMethod const M_DOCUMENTDB_DATABASE_SCHEMA_METADATA_GET_SCHEMA_NAME =
+                        JniMethod("getSchemaName", "()Ljava/lang/String;", false);
+
 
                 const char* const C_DRIVERMANAGER = "java/sql/DriverManager";
                 JniMethod const M_DRIVERMANAGER_GET_CONNECTION = 
@@ -493,6 +501,10 @@ namespace ignite
                     //m_DocumentDbConnectionInit = FindMethod(env, c_DocumentDbConnection, M_DOCUMENTDB_CONNECTION_PROPERTIES_INIT);
                     m_DocumentDbConnectionGetSshLocalPort = FindMethod(env, c_DocumentDbConnection, M_DOCUMENTDB_CONNECTION_GET_SSH_LOCAL_PORT);
                     m_DocumentDbConnectionIsSshTunnelActive = FindMethod(env, c_DocumentDbConnection, M_DOCUMENTDB_CONNECTION_IS_SSH_TUNNEL_ACTIVE);
+                    m_DocumentDbConnectionGetDatabaseMetadata = FindMethod(env, c_DocumentDbConnection, M_DOCUMENTDB_CONNECTION_GET_DATABASE_METADATA);
+
+                    c_DocumentDbDatabaseSchemaMetadata = FindClass(env, C_DOCUMENTDB_DATABASE_SCHEMA_METADATA);
+                    m_DocumentDbDatabaseSchemaMetadataGetSchemaName = FindMethod(env, c_DocumentDbDatabaseSchemaMetadata, M_DOCUMENTDB_DATABASE_SCHEMA_METADATA_GET_SCHEMA_NAME);
 
                     c_DriverManager = FindClass(env, C_DRIVERMANAGER);
                     m_DriverManagerGetConnection = FindMethod(env, c_DriverManager, M_DRIVERMANAGER_GET_CONNECTION);
@@ -862,6 +874,61 @@ namespace ignite
                         connection.Get()->GetRef(),
                         jvm->GetMembers().m_DocumentDbConnectionGetSshLocalPort);
                     ExceptionCheck(env, &errInfo);
+                    return errInfo.code == IGNITE_JNI_ERR_SUCCESS;
+                }
+
+                bool JniContext::DocumentDbConnectionGetDatabaseMetadata(
+                    const SharedPointer< GlobalJObject >& connection,
+                    SharedPointer< GlobalJObject >& metadata,
+                    JniErrorInfo& errInfo) {
+                    if (!connection.Get()) {
+                        errInfo.code = IGNITE_JNI_ERR_GENERIC;
+                        errInfo.errMsg = "Connection object must be set.";
+                        return false;
+                    }
+                    JNIEnv* env = Attach();
+                    jobject result = env->CallObjectMethod(
+                        connection.Get()->GetRef(),
+                        jvm->GetMembers().m_DocumentDbConnectionGetDatabaseMetadata);
+                    ExceptionCheck(env, &errInfo);
+
+                    if (!result || errInfo.code != IGNITE_JNI_ERR_SUCCESS) {
+                        metadata = nullptr;
+                        return false;
+                    }
+
+                    metadata = SharedPointer< GlobalJObject >(
+                        new GlobalJObject(env, env->NewGlobalRef(result)));
+                    return errInfo.code == IGNITE_JNI_ERR_SUCCESS;
+                }
+
+                bool JniContext::DocumentDbDatabaseSchemaMetadataGetSchemaName(
+                    const SharedPointer< GlobalJObject >& databaseMetadata,
+                    std::string& value, bool& wasNull, JniErrorInfo& errInfo)
+                {
+                    if (!databaseMetadata.Get()) {
+                        errInfo.code = IGNITE_JNI_ERR_GENERIC;
+                        errInfo.errMsg = "DatabaseMetadata object must be set.";
+                        return false;
+                    }
+                    JNIEnv* env = Attach();
+                    jobject result = env->CallObjectMethod(
+                        databaseMetadata.Get()->GetRef(),
+                        jvm->GetMembers().m_DocumentDbDatabaseSchemaMetadataGetSchemaName);
+                    ExceptionCheck(env, &errInfo);
+
+                    if (errInfo.code == IGNITE_JNI_ERR_SUCCESS) {
+                        wasNull = !result;
+                        if (result != nullptr) {
+                            jboolean isCopy;
+                            const char* utfChars = env->GetStringUTFChars(
+                                (jstring)result, &isCopy);
+                            value = std::string(utfChars);
+                            env->ReleaseStringUTFChars((jstring)result,
+                                                       utfChars);
+                        }
+                    }
+
                     return errInfo.code == IGNITE_JNI_ERR_SUCCESS;
                 }
 


### PR DESCRIPTION
### Summary

Implement JNI method call for DocumentDbConnection.getDatabaseMetadata().

### Description

This branch is based on AD-521 branch. Code changes will be better reflected when AD-521 is merged. 

To-do's:
- [x] implement JNI wrapper calls
- [x] unit test
- - [x] check for properties

### Related Issue

<!--- Link to issue where this is tracked -->

Getting database metadata properties from the connection properties
The idea is expose the properties

DocumentDbConnection.getDatabaseMetadata()

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
<!-- Any additional reviewers -->
