### PR TITLE
[ODBC] Create wrapper classes for DocumentDbConnection and ResultSet to enforce the close on dispose.

### DIFF
--- a/src/odbc-test/CMakeLists.txt
+++ b/src/odbc-test/CMakeLists.txt
@@ -69,7 +69,9 @@ set(SOURCES
          ../odbc/src/dsn_config.cpp
          ../odbc/src/environment.cpp
          ../odbc/src/ignite_error.cpp
+         ../odbc/src/jni/database_metadata.cpp
          ../odbc/src/jni/java.cpp
+         ../odbc/src/jni/result_set.cpp
          ../odbc/src/log.cpp
          ../odbc/src/message.cpp
          ../odbc/src/meta/column_meta.cpp

--- a/src/odbc-test/src/connection_test.cpp
+++ b/src/odbc-test/src/connection_test.cpp
@@ -28,6 +28,9 @@
 
 #include "test_utils.h"
 #include "odbc_test_suite.h"
+#include "ignite/odbc/common/concurrent.h"
+#include "ignite/odbc/connection.h"
+#include "ignite/odbc/jni/database_metadata.h"
 
 using namespace ignite;
 using namespace ignite_test;
@@ -91,6 +94,17 @@ BOOST_AUTO_TEST_CASE(TestConnectionRestore)
     CreateDsnConnectionString(connectionString);
 
     Connect(connectionString);
+    auto connection = static_cast<odbc::Connection*>(dbc);
+    ignite::IgniteError error;
+
+    SharedPointer< DatabaseMetaData > databaseMetaData;
+    auto config = connection->GetConfiguration();
+    databaseMetaData = connection->GetMetaData(error);
+    //if (error.GetCode() != IgniteError::IGNITE_SUCCESS) {
+    //    Disconnect();
+    //    BOOST_FAIL(error.GetText());
+    //}
+    //BOOST_CHECK(databaseMetaData.IsValid());
     Disconnect();
 }
 

--- a/src/odbc/CMakeLists.txt
+++ b/src/odbc/CMakeLists.txt
@@ -47,7 +47,10 @@ set(SOURCES src/app/application_data_buffer.cpp
         src/diagnostic/diagnosable_adapter.cpp
         src/diagnostic/diagnostic_record.cpp
         src/diagnostic/diagnostic_record_storage.cpp
+        src/jni/database_metadata.cpp
+        src/jni/documentdb_connection.cpp
         src/jni/java.cpp
+        src/jni/result_set.cpp
         src/environment.cpp
         src/meta/column_meta.cpp
         src/meta/table_meta.cpp

--- a/src/odbc/include/ignite/odbc/connection.h
+++ b/src/odbc/include/ignite/odbc/connection.h
@@ -28,11 +28,15 @@
 #include "ignite/odbc/diagnostic/diagnosable_adapter.h"
 #include "ignite/odbc/streaming/streaming_context.h"
 #include "ignite/odbc/odbc_error.h"
+#include "ignite/odbc/jni/database_metadata.h"
 #include "ignite/odbc/jni/java.h"
 #include <ignite/odbc/common/concurrent.h>
 #include "ignite/odbc/end_point.h"
 
+using ignite::odbc::common::concurrent::SharedPointer;
 using ignite::odbc::jni::java::GlobalJObject;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::DatabaseMetaData;
 
 namespace ignite
 {
@@ -123,40 +127,12 @@ namespace ignite
              */
             Statement* CreateStatement();
 
-            /**
-             * Send data by established connection.
-             * Uses connection timeout.
-             *
-             * @param data Data buffer.
-             * @param len Data length.
-             * @return @c true on success, @c false on timeout.
-             * @throw OdbcError on error.
+            /** 
+             * Gets the database metadata for the connection.
+             * 
+             * @return SharedPointer to DatabaseMetaData.
              */
-            bool Send(const int8_t* data, size_t len)
-            {
-                return Send(data, len, timeout);
-            }
-
-            /**
-             * Send data by established connection.
-             *
-             * @param data Data buffer.
-             * @param len Data length.
-             * @param timeout Timeout.
-             * @return @c true on success, @c false on timeout.
-             * @throw OdbcError on error.
-             */
-            bool Send(const int8_t* data, size_t len, int32_t timeout);
-
-            /**
-             * Receive next message.
-             *
-             * @param msg Buffer for message.
-             * @param timeout Timeout.
-             * @return @c true on success, @c false on timeout.
-             * @throw OdbcError on error.
-             */
-            bool Receive(std::vector<int8_t>& msg, int32_t timeout);
+            SharedPointer< DatabaseMetaData > GetMetaData(IgniteError& err);
 
             /**
              * Get name of the assotiated schema.
@@ -214,22 +190,7 @@ namespace ignite
             template<typename ReqT, typename RspT>
             bool SyncMessage(const ReqT& req, RspT& rsp, int32_t timeout)
             {
-                EnsureConnected();
-
-                std::vector<int8_t> tempBuffer;
-
-                parser.Encode(req, tempBuffer);
-
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
-
-                if (!success)
-                    return false;
-
-                success = Receive(tempBuffer, timeout);
-
-                if (!success)
-                    return false;
-
+                // TODO: Remove when unnecessary.
                 return true;
             }
 
@@ -244,23 +205,7 @@ namespace ignite
             template<typename ReqT, typename RspT>
             void SyncMessage(const ReqT& req, RspT& rsp)
             {
-                EnsureConnected();
-
-                std::vector<int8_t> tempBuffer;
-
-                parser.Encode(req, tempBuffer);
-
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
-
-                if (!success)
-                    throw OdbcError(SqlState::SHYT01_CONNECTION_TIMEOUT, "Send operation timed out");
-
-                success = Receive(tempBuffer, timeout);
-
-                if (!success)
-                    throw OdbcError(SqlState::SHYT01_CONNECTION_TIMEOUT, "Receive operation timed out");
-
-                parser.Decode(rsp, tempBuffer);
+                // TODO: Remove when unnecessary.
             }
 
             /**
@@ -273,16 +218,7 @@ namespace ignite
             template<typename ReqT>
             void SendRequest(const ReqT& req)
             {
-                EnsureConnected();
-
-                std::vector<int8_t> tempBuffer;
-
-                parser.Encode(req, tempBuffer);
-
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
-
-                if (!success)
-                    throw OdbcError(SqlState::SHYT01_CONNECTION_TIMEOUT, "Send operation timed out");
+                // TODO: Remove when unnecessary.
             }
 
             /**
@@ -345,22 +281,7 @@ namespace ignite
             template<typename ReqT, typename RspT>
             bool InternalSyncMessage(const ReqT& req, RspT& rsp, int32_t timeout)
             {
-                std::vector<int8_t> tempBuffer;
-
-                parser.Encode(req, tempBuffer);
-
-                bool success = Send(tempBuffer.data(), tempBuffer.size(), timeout);
-
-                if (!success)
-                    return false;
-
-                success = Receive(tempBuffer, timeout);
-
-                if (!success)
-                    return false;
-
-                parser.Decode(rsp, tempBuffer);
-
+                // TODO: Remove when unnecessary.
                 return true;
             }
 
@@ -457,26 +378,6 @@ namespace ignite
             SqlResult::Type InternalSetAttribute(int attr, void* value, SQLINTEGER valueLen);
 
             /**
-             * Receive specified number of bytes.
-             *
-             * @param dst Buffer for data.
-             * @param len Number of bytes to receive.
-             * @param timeout Timeout.
-             * @return Operation result.
-             */
-            OperationResult::T ReceiveAll(void* dst, size_t len, int32_t timeout);
-
-            /**
-             * Send specified number of bytes.
-             *
-             * @param data Data buffer.
-             * @param len Data length.
-             * @param timeout Timeout.
-             * @return Operation result.
-             */
-            OperationResult::T SendAll(const int8_t* data, size_t len, int32_t timeout);
-
-            /**
              * Perform handshake request.
              *
              * @return Operation result.
@@ -504,6 +405,13 @@ namespace ignite
             void SetJvmOptions(const std::string& cp);
 
             /**
+             * Get the singleton instance of the JNI context for the connection.
+             *
+             * @return JNI context.
+             */
+            SharedPointer< JniContext > GetJniContext();
+
+            /**
              * De-initializes the JVM options
              */
             void Deinit();
@@ -525,16 +433,13 @@ namespace ignite
             Environment* env;
 
             /** Connection timeout in seconds. */
-            int32_t timeout;
+            int32_t timeout = 0;
 
             /** Login timeout in seconds. */
-            int32_t loginTimeout;
+            int32_t loginTimeout = DEFAULT_CONNECT_TIMEOUT;
 
             /** Autocommit flag. */
-            bool autoCommit;
-
-            /** Message parser. */
-            Parser parser;
+            bool autoCommit = true;
 
             /** Configuration. */
             config::Configuration config;
@@ -543,7 +448,9 @@ namespace ignite
             config::ConnectionInfo info;
 
             /** Java connection object */
-            SharedPointer< GlobalJObject > connection;
+            SharedPointer< GlobalJObject > _connection;
+
+            SharedPointer< JniContext > _jniContext;
 
             /** JVM options */
             std::vector< char* > opts;

--- a/src/odbc/include/ignite/odbc/ignite_error.h
+++ b/src/odbc/include/ignite/odbc/ignite_error.h
@@ -120,6 +120,9 @@ namespace ignite
             /** JVM error: no such method. */
             static const int IGNITE_ERR_JVM_NO_SUCH_METHOD = 7;
 
+            /** JNI error: getting database metadata */
+            static const int IGNITE_ERR_JNI_GET_DATABASE_METADATA = 101;
+
             /** Memory operation error. */
             static const int IGNITE_ERR_MEMORY = 1001;
 

--- a/src/odbc/include/ignite/odbc/jni/database_metadata.h
+++ b/src/odbc/include/ignite/odbc/jni/database_metadata.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_ODBC_JNI_DATABASE_METADATA
+#define _IGNITE_ODBC_JNI_DATABASE_METADATA
+
+#include <string>
+#include <ignite/odbc/common/concurrent.h>
+#include <ignite/odbc/jni/java.h>
+#include <ignite/odbc/jni/result_set.h>
+
+using ignite::odbc::common::concurrent::SharedPointer;
+using ignite::odbc::jni::java::GlobalJObject;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::java::JniErrorInfo;
+
+namespace ignite {
+namespace odbc {
+namespace jni {
+class DatabaseMetaData {
+   public:
+    DatabaseMetaData(SharedPointer< JniContext > jniContext,
+                     SharedPointer< GlobalJObject > connection);
+    ~DatabaseMetaData() = default;
+
+    SharedPointer< ResultSet > GetTables(
+        const std::string& catalog,
+        const std::string& schemaPattern,
+        const std::string& tableNamePattern,
+        const std::vector< std::string >& types,
+        JniErrorInfo& errInfo);
+
+   private:
+    SharedPointer< JniContext > _jniContext;
+    SharedPointer< GlobalJObject > _connection;
+};
+}  // namespace
+}  // namespace odbc
+}  // namespace ignite
+
+#endif // _IGNITE_ODBC_JNI_DATABASE_METADATA

--- a/src/odbc/include/ignite/odbc/jni/documentdb_connection.h
+++ b/src/odbc/include/ignite/odbc/jni/documentdb_connection.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_ODBC_JNI_DOCUMENTDB_CONNECTION
+#define _IGNITE_ODBC_JNI_DOCUMENTDB_CONNECTION
+
+#include <ignite/odbc/common/concurrent.h>
+#include <ignite/odbc/jni/java.h>
+
+using ignite::odbc::common::concurrent::SharedPointer;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::java::GlobalJObject;
+
+namespace ignite {
+    namespace odbc {
+        namespace jni {
+            class DocumentDbConnection {
+               public:
+                DocumentDbConnection(SharedPointer< JniContext > jniContext, SharedPointer< GlobalJObject > connection);
+                ~DocumentDbConnection();
+
+               private:
+                SharedPointer< JniContext > _jniContext;
+                SharedPointer< GlobalJObject > _connection;
+            };
+        }  // namespace jni
+    }  // namespace odbc
+}  // namespace ignite
+
+#endif // _IGNITE_ODBC_JNI_DOCUMENTDB_CONNECTION

--- a/src/odbc/include/ignite/odbc/jni/result_set.h
+++ b/src/odbc/include/ignite/odbc/jni/result_set.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_ODBC_JNI_RESULT_SET
+#define _IGNITE_ODBC_JNI_RESULT_SET
+
+#include <string>
+#include <ignite/odbc/common/concurrent.h>
+#include <ignite/odbc/jni/java.h>
+
+using ignite::odbc::common::concurrent::SharedPointer;
+using ignite::odbc::jni::java::GlobalJObject;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::java::JniErrorInfo;
+
+namespace ignite {
+namespace odbc {
+namespace jni {
+class ResultSet {
+   public:
+    ResultSet(SharedPointer< JniContext > jniContext,
+              SharedPointer< GlobalJObject > resultSet);
+    ~ResultSet();
+
+    bool Next(bool& hasNext, JniErrorInfo& errInfo);
+    bool GetString(const int columnIndex, std::string& value, bool& wasNull,
+                   JniErrorInfo& errInfo);
+    bool GetString(const std::string& columnName, std::string& value, bool& wasNull,
+                   JniErrorInfo& errInfo);
+    bool GetInt(const int columnIndex, int& value, bool& wasNull,
+                   JniErrorInfo& errInfo);
+    bool GetInt(const std::string& columnName, int& value,
+                   bool& wasNull, JniErrorInfo& errInfo);
+
+   private:
+    SharedPointer< JniContext > _jniContext;
+    SharedPointer< GlobalJObject > _resultSet;
+};
+}
+}  // namespace odbc
+}  // namespace ignite
+
+#endif // _IGNITE_ODBC_JNI_RESULT_SET

--- a/src/odbc/src/jni/database_metadata.cpp
+++ b/src/odbc/src/jni/database_metadata.cpp
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ignite/odbc/jni/database_metadata.h>
+
+namespace ignite {
+namespace odbc {
+namespace jni {
+DatabaseMetaData::DatabaseMetaData(SharedPointer< JniContext > jniContext,
+                                   SharedPointer< GlobalJObject > connection)
+    : _jniContext(jniContext), _connection(connection) {
+}
+SharedPointer< ResultSet > DatabaseMetaData::GetTables(const std::string& catalog,
+                                     const std::string& schemaPattern,
+                                     const std::string& tableNamePattern,
+                                     const std::vector< std::string >& types, JniErrorInfo& errInfo) {
+    return nullptr;
+}
+
+}  // namespace
+}  // namespace odbc
+}  // namespace ignite

--- a/src/odbc/src/jni/documentdb_connection.cpp
+++ b/src/odbc/src/jni/documentdb_connection.cpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ignite/odbc/jni/documentdb_connection.h>
+
+using ignite::odbc::jni::java::JniErrorInfo;
+
+namespace ignite {
+    namespace odbc {
+        namespace jni
+        {
+            DocumentDbConnection::DocumentDbConnection(
+                SharedPointer< JniContext > jniContext,
+                SharedPointer< GlobalJObject > connection)
+                : _jniContext(jniContext), _connection(connection) {
+            }
+
+            DocumentDbConnection::~DocumentDbConnection() {
+                if (_jniContext.Get() != nullptr && _connection.Get() != nullptr) {
+                    JniErrorInfo errInfo;
+                    _jniContext.Get()->ConnectionClose(_connection, errInfo);
+                    _connection = nullptr;
+                    _jniContext = nullptr;
+                }
+            }
+        }  // namespace jni
+    }  // namespace odbc
+}  // namespace ignite

--- a/src/odbc/src/jni/result_set.cpp
+++ b/src/odbc/src/jni/result_set.cpp
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ignite/odbc/common/concurrent.h>
+#include <ignite/odbc/jni/java.h>
+#include <ignite/odbc/jni/result_set.h>
+
+using ignite::odbc::common::concurrent::SharedPointer;
+using ignite::odbc::jni::java::GlobalJObject;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::java::JniErrorInfo;
+
+namespace ignite 
+{
+    namespace odbc 
+    {
+        namespace jni 
+        {
+            ResultSet::ResultSet(SharedPointer< JniContext > jniContext,
+                                SharedPointer< GlobalJObject > resultSet)
+            : _jniContext(jniContext), _resultSet(resultSet) {
+            }
+
+            ResultSet::~ResultSet() {
+                if (_jniContext.Get() != nullptr) {
+                    if (_resultSet.Get() != nullptr) {
+                        JniErrorInfo errInfo;
+                        _jniContext.Get()->ResultSetClose(_resultSet, errInfo);
+                        _resultSet = nullptr;
+                    }
+                    _jniContext = nullptr;
+                }
+            }
+
+            bool Next(bool& hasNext, JniErrorInfo& errInfo) {
+                return false;
+            }
+
+            bool GetString(const int columnIndex, std::string& value,
+                           bool& wasNull, JniErrorInfo& errInfo) {
+                return false;
+            }
+
+            bool GetString(const std::string& columnName, std::string& value,
+                           bool& wasNull, JniErrorInfo& errInfo) {
+                return false;
+            }
+
+            bool GetInt(const int columnIndex, int& value, bool& wasNull,
+                        JniErrorInfo& errInfo) {
+                return false;
+            }
+
+            bool GetInt(const std::string& columnName, int& value,
+                        bool& wasNull, JniErrorInfo& errInfo) {
+                return false;
+            }
+
+        }  // namespace jni
+    }  // namespace odbc
+}  // namespace ignite

--- a/src/odbc/src/odbc.cpp
+++ b/src/odbc/src/odbc.cpp
@@ -165,7 +165,7 @@ namespace ignite
 
         *stmt = SQL_NULL_HDBC;
 
-        Connection *connection = reinterpret_cast<Connection*>(conn);
+        auto connection = static_cast<Connection*>(conn);
 
         if (!connection)
             return SQL_INVALID_HANDLE;

--- a/src/odbc/src/query/table_metadata_query.cpp
+++ b/src/odbc/src/query/table_metadata_query.cpp
@@ -19,10 +19,15 @@
 
 #include "ignite/odbc/type_traits.h"
 #include "ignite/odbc/connection.h"
+#include "ignite/odbc/jni/java.h"
 #include "ignite/odbc/message.h"
 #include "ignite/odbc/log.h"
 #include "ignite/odbc/odbc_error.h"
 #include "ignite/odbc/query/table_metadata_query.h"
+
+using ignite::odbc::common::concurrent::SharedPointer;
+using ignite::odbc::jni::java::JniContext;
+using ignite::odbc::jni::java::JniHandlers;
 
 namespace
 {


### PR DESCRIPTION
### Summary

[ODBC] Create wrapper classes for DocumentDbConnection and ResultSet to enforce the close on dispose.

### Description

Write wrapper classes to access JNI methods on DocumentDbConnection and ResulSet.

### Related Issue

https://bitquill.atlassian.net/browse/AD-594

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
<!-- Any additional reviewers -->
