### PR TITLE
[AD-673] bump JDBC version to 1.2.1

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -25,7 +25,7 @@ env:
   DOC_DB_REMOTE_PORT: 27017
   DOC_DB_PRIV_KEY_FILE: ~/certs/docdb-sshtunnel.pem
   DOC_DB_ODBC_INTEGRATION_TEST: 1
-  JDBC_DRIVER_VERSION: "1.2.0"
+  JDBC_DRIVER_VERSION: "1.2.1"
 
 jobs:
   build-mac:

--- a/build_mac_debug64.sh
+++ b/build_mac_debug64.sh
@@ -10,7 +10,7 @@ cd ..
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then 
-    JDBC_DRIVER_VERSION="1.2.0"
+    JDBC_DRIVER_VERSION="1.2.1"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/build_mac_release64.sh
+++ b/build_mac_release64.sh
@@ -10,7 +10,7 @@ make -j 4
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then 
-    JDBC_DRIVER_VERSION="1.2.0"
+    JDBC_DRIVER_VERSION="1.2.1"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -29,7 +29,7 @@ $DRIVER_BIN_DIR = "$DRIVER_BUILD_DIR\..\bin\$CONFIGURATION"
 New-Item -Path $DRIVER_BIN_DIR -ItemType Directory -Force | Out-Null
 
 # Download the JDBC driver
-$JDBC_DRIVER_VERSION = if ($JDBC_DRIVER_VERSION -eq $null) { "1.2.0" } else { $JDBC_DRIVER_VERSION }
+$JDBC_DRIVER_VERSION = if ($JDBC_DRIVER_VERSION -eq $null) { "1.2.1" } else { $JDBC_DRIVER_VERSION }
 $JDBC_DRIVER_FILENAME = "documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 $JDBC_DRIVER_FULLPATH = "$DRIVER_BIN_DIR\libs\$JDBC_DRIVER_FILENAME"
 if (-not (Test-Path -Path $JDBC_DRIVER_FULLPATH -PathType Leaf)) {


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
bump JDBC version to 1.2.1
### Description

<!--- Details of what you changed -->
This PR should be merged after JDBC 1.2.1 is released. 
This PR updates JDBC version from 1.2.0 to 1.2.1.
- [x] update mac scripts
- [x] update windows scripts

### Related Issue

<!--- Link to issue where this is tracked -->
https://bitquill.atlassian.net/browse/AD-673
### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@andiem-bq
@birschick-bq
<!-- Any additional reviewers -->
