### PR TITLE
[AD-735] large dataset crash issue

### DIFF
--- a/src/tests/performance/include/performance_test_runner.h
+++ b/src/tests/performance/include/performance_test_runner.h
@@ -31,7 +31,7 @@ typedef SQLLEN SQLROWOFFSET;
  * GLOBAL CONSTANTS
  *******************************************************/
 
-#define BIND_SIZE 255 // used for SQLBindCol function
+#define BIND_SIZE 512 // used for SQLBindCol function
 
 // CSV header definitions (input csv file must match)
 #define QUERY_HEADER "query"


### PR DESCRIPTION
### Summary
ODBC driver will not run on large document tests

<!--- General summary / title -->

### Description
The performance test crashes for large document tests. 

<!--- Details of what you changed -->
1. The root cause is the wrong memory is passed to SQLBindCol(). The parameter TargetValuePtr is passed &cols[i][0].data_dat[i]. The i could exceed 255 for large table while its max valid value should be 254. The correct value should be 0.
2. The SQLExtendedFetch is deprecated. Replace it with SQLFetch.

### Related Issue

<!--- Link to issue where this is tracked -->
https://bitquill.atlassian.net/browse/AD-735

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
<!-- Any additional reviewers -->
