### PR TITLE
[AD-751] make getColumns/getTables pass nullptr for catalog and schema params to JDBC

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -26,7 +26,7 @@ env:
   DOC_DB_PRIV_KEY_FILE: ~/certs/docdb-sshtunnel.pem
   DOC_DB_LOG_PATH: "${{github.workspace}}/build/odbc/logs"
   DOC_DB_LOG_LEVEL: "debug"
-  JDBC_DRIVER_VERSION: "1.2.3"
+  JDBC_DRIVER_VERSION: "1.2.4"
   JAVA_HOME: "/usr/lib/jvm/java-17-amazon-corretto/"
 
 jobs:

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -27,7 +27,7 @@ env:
   DOC_DB_ODBC_INTEGRATION_TEST: 1
   DOC_DB_LOG_PATH: "${{github.workspace}}/build/odbc/logs"
   DOC_DB_LOG_LEVEL: "debug"
-  JDBC_DRIVER_VERSION: "1.2.3"
+  JDBC_DRIVER_VERSION: "1.2.4"
 
 jobs:
   build-mac:

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -29,7 +29,7 @@ env:
   DOC_DB_PRIV_KEY_FILE: ~/certs/docdb-sshtunnel.pem
   DOC_DB_LOG_PATH: "${{github.workspace}}/build/odbc/logs"
   DOC_DB_LOG_LEVEL: "debug"
-  JDBC_DRIVER_VERSION: "1.2.3"
+  JDBC_DRIVER_VERSION: "1.2.4"
   MONGO_IMPORT_COMMAND: "C:/ProgramData/chocolatey/lib/mongodb-database-tools/tools/mongodb-database-tools-windows-x86_64-100.5.2binmongoimport.exe"
 
 jobs:
@@ -44,7 +44,6 @@ jobs:
     #   run: |
     #     choco install cppcheck -y -d
     #     echo "C:\Program Files\Cppcheck" >> $env:GITHUB_PATH
-        
     # - name: run-cppcheck
     #   id: run-cppcheck
     #   run: |
@@ -193,7 +192,7 @@ jobs:
     #   uses: actions/upload-artifact@v3
     #   with:
     #     name: cppcheck-results
-    #     path: cppcheck-results.log 
+    #     path: cppcheck-results.log
     - name: Get Java distribution
       uses: actions/setup-java@v2
       with:

--- a/build_linux_debug64.sh
+++ b/build_linux_debug64.sh
@@ -13,7 +13,7 @@ cd ..
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then 
-    JDBC_DRIVER_VERSION="1.2.3"
+    JDBC_DRIVER_VERSION="1.2.4"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/build_linux_release64_deb.sh
+++ b/build_linux_release64_deb.sh
@@ -10,7 +10,7 @@ cd ..
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then
-    JDBC_DRIVER_VERSION="1.2.3"
+    JDBC_DRIVER_VERSION="1.2.4"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/build_mac_debug64.sh
+++ b/build_mac_debug64.sh
@@ -13,7 +13,7 @@ cd ..
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then 
-    JDBC_DRIVER_VERSION="1.2.3"
+    JDBC_DRIVER_VERSION="1.2.4"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/build_mac_release64.sh
+++ b/build_mac_release64.sh
@@ -10,7 +10,7 @@ make -j 4
 
 # Download the DocumentDB JDBC Driver
 if [ -z "$JDBC_DRIVER_VERSION" ]; then 
-    JDBC_DRIVER_VERSION="1.2.3"
+    JDBC_DRIVER_VERSION="1.2.4"
 fi
 JDBC_DRIVER_FILENAME="documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 JDBC_DRIVER_FULLPATH="$DRIVER_BIN_DIR/libs/$JDBC_DRIVER_FILENAME"

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -29,7 +29,7 @@ $DRIVER_BIN_DIR = "$DRIVER_BUILD_DIR\..\bin\$CONFIGURATION"
 New-Item -Path $DRIVER_BIN_DIR -ItemType Directory -Force | Out-Null
 
 # Download the JDBC driver
-$JDBC_DRIVER_VERSION = if ($JDBC_DRIVER_VERSION -eq $null) { "1.2.3" } else { $JDBC_DRIVER_VERSION }
+$JDBC_DRIVER_VERSION = if ($JDBC_DRIVER_VERSION -eq $null) { "1.2.4" } else { $JDBC_DRIVER_VERSION }
 $JDBC_DRIVER_FILENAME = "documentdb-jdbc-$JDBC_DRIVER_VERSION-all.jar"
 $JDBC_DRIVER_FULLPATH = "$DRIVER_BIN_DIR\libs\$JDBC_DRIVER_FILENAME"
 if (-not (Test-Path -Path $JDBC_DRIVER_FULLPATH -PathType Leaf)) {

--- a/src/odbc-test/src/java_test.cpp
+++ b/src/odbc-test/src/java_test.cpp
@@ -363,10 +363,10 @@ BOOST_AUTO_TEST_CASE(TestDatabaseMetaDataGetTables) {
   }
   BOOST_REQUIRE(databaseMetaData.Get());
 
-  std::string catalog;
-  std::string schemaPattern;
-  std::string tableNamePattern;
-  std::vector< std::string > types(
+  boost::optional< std::string > catalog = boost::none;
+  boost::optional< std::string > schemaPattern = boost::none;
+  std::string tableNamePattern = "%";
+  boost::optional < std::vector< std::string > > types(
       {"TABLE"});  // Need to specify this to get result.
   SharedPointer< GlobalJObject > resultSet;
   if (_ctx.Get()->DatabaseMetaDataGetTables(databaseMetaData, catalog,
@@ -510,10 +510,10 @@ BOOST_AUTO_TEST_CASE(TestDatabaseMetaDataGetColumns) {
   }
   BOOST_REQUIRE(databaseMetaData.Get());
 
-  std::string catalog;
-  std::string schemaPattern;
-  std::string tableNamePattern;
-  std::string columnNamePattern;
+  boost::optional< std::string > catalog;
+  boost::optional< std::string > schemaPattern;
+  std::string tableNamePattern = "%";
+  std::string columnNamePattern = "%";
   SharedPointer< GlobalJObject > resultSet;
   if (_ctx.Get()->DatabaseMetaDataGetColumns(
           databaseMetaData, catalog, schemaPattern, tableNamePattern,

--- a/src/odbc-test/src/jni_test.cpp
+++ b/src/odbc-test/src/jni_test.cpp
@@ -554,10 +554,11 @@ BOOST_AUTO_TEST_CASE(TestDocumentDbDatabaseMetaDataGetTables) {
       dbConnection.GetMetaData(errInfo);
   BOOST_REQUIRE(databaseMetaData.IsValid());
 
-  std::string catalog;
-  std::string schemaPattern;
+  boost::optional< std::string > catalog;
+  boost::optional< std::string > schemaPattern;
   std::string tablePattern;
-  std::vector< std::string > types = {"TABLE"};
+  boost::optional< std::vector< std::string > > types(
+      std::vector< std::string >({"TABLE"}));
   SharedPointer< ResultSet > resultSet = databaseMetaData.Get()->GetTables(
       catalog, schemaPattern, tablePattern, types, errInfo);
   BOOST_CHECK(resultSet.IsValid());
@@ -635,10 +636,10 @@ BOOST_AUTO_TEST_CASE(TestDocumentDbDatabaseMetaDataGetColumns) {
       dbConnection.GetMetaData(errInfo);
   BOOST_REQUIRE(databaseMetaData.IsValid());
 
-  std::string catalog;
-  std::string schemaPattern = DATABASE_NAME;
+  boost::optional< std::string > catalog;
+  boost::optional< std::string > schemaPattern = DATABASE_NAME;
   std::string tablePattern = "jni_test_001";
-  std::string columnNamePattern;
+  std::string columnNamePattern = "%";
   SharedPointer< ResultSet > resultSet = databaseMetaData.Get()->GetColumns(
       catalog, schemaPattern, tablePattern, columnNamePattern, errInfo);
   BOOST_CHECK(resultSet.IsValid());

--- a/src/odbc/include/ignite/odbc/jni/database_metadata.h
+++ b/src/odbc/include/ignite/odbc/jni/database_metadata.h
@@ -48,19 +48,19 @@ class DatabaseMetaData {
    * critera in catalog (not supported), schemaPattern, tablePattern
    * and types of tables.
    */
-  SharedPointer< ResultSet > GetTables(const std::string& catalog,
-                                       const std::string& schemaPattern,
+  SharedPointer< ResultSet > GetTables(const boost::optional< std::string >& catalog,
+                                       const boost::optional< std::string >& schemaPattern,
                                        const std::string& tableNamePattern,
-                                       const std::vector< std::string >& types,
+                                       const boost::optional< std::vector< std::string > >& types,
                                        JniErrorInfo& errInfo);
 
   /**
    * Query the columns in the database according to the given
-   * search critera in catalog (not supported), schemaPattern,
+   * search critera in catalog (not supported), schemaPattern (nullable),
    * tablePattern and columnPattern.
    */
-  SharedPointer< ResultSet > GetColumns(const std::string& catalog,
-                                        const std::string& schemaPattern,
+  SharedPointer< ResultSet > GetColumns(const boost::optional< std::string >& catalog,
+                                        const boost::optional< std::string >& schemaPattern,
                                         const std::string& tableNamePattern,
                                         const std::string& columnNamePattern,
                                         JniErrorInfo& errInfo);

--- a/src/odbc/include/ignite/odbc/jni/java.h
+++ b/src/odbc/include/ignite/odbc/jni/java.h
@@ -520,14 +520,16 @@ class IGNITE_IMPORT_EXPORT JniContext {
 
   JniErrorCode DatabaseMetaDataGetTables(
       const SharedPointer< GlobalJObject >& databaseMetaData,
-      const std::string& catalog, const std::string& schemaPattern,
+      const boost::optional< std::string >& catalog,
+      const boost::optional< std::string >& schemaPattern,
       const std::string& tableNamePattern,
-      const std::vector< std::string >& types,
+      const boost::optional< std::vector< std::string > >& types,
       SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo);
 
   JniErrorCode DatabaseMetaDataGetColumns(
       const SharedPointer< GlobalJObject >& databaseMetaData,
-      const std::string& catalog, const std::string& schemaPattern,
+      const boost::optional< std::string >& catalog,
+      const boost::optional< std::string >& schemaPattern,
       const std::string& tableNamePattern, const std::string& columnNamePattern,
       SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo);
 

--- a/src/odbc/include/ignite/odbc/query/column_metadata_query.h
+++ b/src/odbc/include/ignite/odbc/query/column_metadata_query.h
@@ -43,8 +43,10 @@ class ColumnMetadataQuery : public Query {
    * @param column Column search pattern.
    */
   ColumnMetadataQuery(diagnostic::DiagnosableAdapter& diag,
-                      Connection& connection, const std::string& catalog,
-                      const std::string& schema, const std::string& table,
+                      Connection& connection,
+                      const boost::optional< std::string >& catalog,
+                      const boost::optional< std::string >& schema,
+                      const std::string& table,
                       const std::string& column);
 
   /**
@@ -125,10 +127,10 @@ class ColumnMetadataQuery : public Query {
   Connection& connection;
 
   /** Catalog search pattern. */
-  std::string catalog;
+  boost::optional< std::string > catalog;
 
   /** Schema search pattern. */
-  std::string schema;
+  boost::optional< std::string > schema;
 
   /** Table search pattern. */
   std::string table;

--- a/src/odbc/include/ignite/odbc/query/table_metadata_query.h
+++ b/src/odbc/include/ignite/odbc/query/table_metadata_query.h
@@ -43,9 +43,11 @@ class TableMetadataQuery : public Query {
    * @param tableType Table type search pattern.
    */
   TableMetadataQuery(diagnostic::DiagnosableAdapter& diag,
-                     Connection& connection, const std::string& catalog,
-                     const std::string& schema, const std::string& table,
-                     const std::string& tableType);
+                     Connection& connection,
+                     const boost::optional< std::string >& catalog,
+                     const boost::optional< std::string >& schema,
+                     const std::string& table,
+                     const boost::optional< std::string >& tableType);
 
   /**
    * Destructor.
@@ -154,16 +156,16 @@ class TableMetadataQuery : public Query {
   Connection& connection;
 
   /** Catalog search pattern. */
-  std::string catalog;
+  boost::optional< std::string > catalog;
 
   /** Schema search pattern. */
-  std::string schema;
+  boost::optional< std::string > schema;
 
   /** Table search pattern. */
   std::string table;
 
   /** Table type search pattern. */
-  std::string tableType;
+  boost::optional< std::string > tableType;
 
   /** Query executed. */
   bool executed;

--- a/src/odbc/include/ignite/odbc/statement.h
+++ b/src/odbc/include/ignite/odbc/statement.h
@@ -165,27 +165,28 @@ class Statement : public diagnostic::DiagnosableAdapter {
   /**
    * Get columns metadata.
    *
-   * @param schema Schema search pattern.
+   * @param catalog Catalog search pattern, nullable.
+   * @param schema Schema search pattern, nullable.
    * @param table Table search pattern.
    * @param column Column search pattern.
    */
-  void ExecuteGetColumnsMetaQuery(const std::string& catalog,
-                                  const std::string& schema,
+  void ExecuteGetColumnsMetaQuery(const boost::optional< std::string >& catalog,
+                                  const boost::optional< std::string >& schema,
                                   const std::string& table,
                                   const std::string& column);
 
   /**
    * Get tables metadata.
    *
-   * @param catalog Catalog search pattern.
-   * @param schema Schema search pattern.
+   * @param catalog Catalog search pattern, nullable.
+   * @param schema Schema search pattern, nullable.
    * @param table Table search pattern.
-   * @param tableType Table type search pattern.
+   * @param tableType Table type search pattern, nullable.
    */
-  void ExecuteGetTablesMetaQuery(const std::string& catalog,
-                                 const std::string& schema,
+  void ExecuteGetTablesMetaQuery(const boost::optional< std::string >& catalog,
+                                 const boost::optional< std::string >& schema,
                                  const std::string& table,
-                                 const std::string& tableType);
+                                 const boost::optional< std::string >& tableType);
 
   /**
    * Get foreign keys.
@@ -538,27 +539,28 @@ class Statement : public diagnostic::DiagnosableAdapter {
    * @param column Column search pattern.
    * @return Operation result.
    */
-  SqlResult::Type InternalExecuteGetColumnsMetaQuery(const std::string& catalog,
-                                                     const std::string& schema,
+  SqlResult::Type InternalExecuteGetColumnsMetaQuery(const boost::optional< std::string >& catalog,
+                                                     const boost::optional< std::string >& schema,
                                                      const std::string& table,
                                                      const std::string& column);
 
   /**
    * Get tables metadata.
    *
-   * @param catalog Catalog search pattern.
-   * @param schema Schema search pattern.
+   * @param catalog Catalog search pattern, nullable.
+   * @param schema Schema search pattern, nullable.
    * @param table Table search pattern.
-   * @param tableType Table type search pattern.
+   * @param tableType Table type search pattern, nullable.
    * @return Operation result.
    */
   SqlResult::Type InternalExecuteGetTablesMetaQuery(
-      const std::string& catalog, const std::string& schema,
-      const std::string& table, const std::string& tableType);
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schema, const std::string& table,
+    const boost::optional< std::string >& tableType);
 
   /**
    * Get foreign keys.
-   * Params for primary key catalog, schema, and table names are ignored. 
+   * Params primaryCatalog, primarySchema, and primaryTable are ignored. 
    *
    * @param primaryCatalog Primary key catalog name.
    * @param primarySchema Primary key schema name.

--- a/src/odbc/src/jni/database_metadata.cpp
+++ b/src/odbc/src/jni/database_metadata.cpp
@@ -31,9 +31,11 @@ namespace ignite {
 namespace odbc {
 namespace jni {
 SharedPointer< ResultSet > DatabaseMetaData::GetTables(
-    const std::string& catalog, const std::string& schemaPattern,
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schemaPattern,
     const std::string& tableNamePattern,
-    const std::vector< std::string >& types, JniErrorInfo& errInfo) {
+    const boost::optional < std::vector< std::string > >& types,
+    JniErrorInfo& errInfo) {
   SharedPointer< GlobalJObject > resultSet;
   JniErrorCode success = _jniContext.Get()->DatabaseMetaDataGetTables(
       _databaseMetaData, catalog, schemaPattern, tableNamePattern, types,
@@ -45,7 +47,8 @@ SharedPointer< ResultSet > DatabaseMetaData::GetTables(
 }
 
 SharedPointer< ResultSet > DatabaseMetaData::GetColumns(
-    const std::string& catalog, const std::string& schemaPattern,
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schemaPattern,
     const std::string& tableNamePattern, const std::string& columnNamePattern,
     JniErrorInfo& errInfo) {
   SharedPointer< GlobalJObject > resultSet;

--- a/src/odbc/src/jni/java.cpp
+++ b/src/odbc/src/jni/java.cpp
@@ -1325,9 +1325,10 @@ JniErrorCode JniContext::ConnectionGetMetaData(
 
 JniErrorCode JniContext::DatabaseMetaDataGetTables(
     const SharedPointer< GlobalJObject >& databaseMetaData,
-    const std::string& catalog, const std::string& schemaPattern,
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schemaPattern,
     const std::string& tableNamePattern,
-    const std::vector< std::string >& types,
+    const boost::optional < std::vector< std::string > >& types,
     SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo) {
   LOG_DEBUG_MSG("DatabaseMetaDataGetTables is called");
 
@@ -1342,14 +1343,22 @@ JniErrorCode JniContext::DatabaseMetaDataGetTables(
   }
 
   JNIEnv* env = Attach();
-  jstring jCatalog = env->NewStringUTF(catalog.c_str());
-  jstring jSchemaPattern = env->NewStringUTF(schemaPattern.c_str());
+  jstring jCatalog = catalog ? env->NewStringUTF(catalog->c_str()) : nullptr;
+  jstring jSchemaPattern =
+      schemaPattern ? env->NewStringUTF(schemaPattern->c_str()) : nullptr;
   jstring jTableNamePattern = env->NewStringUTF(tableNamePattern.c_str());
-  jobjectArray jTypes =
-      env->NewObjectArray(static_cast< jsize >(types.size()),
-                          jvm->GetJavaMembers().c_String, nullptr);
-  for (int i = 0; i < types.size(); i++) {
-    env->SetObjectArrayElement(jTypes, i, env->NewStringUTF(types[i].c_str()));
+  jobjectArray jTypes;
+
+  if (types) {
+    jTypes = env->NewObjectArray(static_cast< jsize >(types->size()),
+                                 jvm->GetJavaMembers().c_String, nullptr);
+    for (int i = 0; i < types->size(); i++) {
+      env->SetObjectArrayElement(jTypes, i,
+                                 env->NewStringUTF((*types)[i].c_str()));
+    }
+  } 
+  else {
+    jTypes = nullptr;
   }
 
   jobject result = env->CallObjectMethod(
@@ -1380,7 +1389,8 @@ JniErrorCode JniContext::DatabaseMetaDataGetTables(
 
 JniErrorCode JniContext::DatabaseMetaDataGetColumns(
     const SharedPointer< GlobalJObject >& databaseMetaData,
-    const std::string& catalog, const std::string& schemaPattern,
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schemaPattern,
     const std::string& tableNamePattern, const std::string& columnNamePattern,
     SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo) {
   LOG_DEBUG_MSG("DatabaseMetaDataGetColumns is called");
@@ -1396,8 +1406,9 @@ JniErrorCode JniContext::DatabaseMetaDataGetColumns(
   }
 
   JNIEnv* env = Attach();
-  jstring jCatalog = env->NewStringUTF(catalog.c_str());
-  jstring jSchemaPattern = env->NewStringUTF(schemaPattern.c_str());
+  jstring jCatalog = catalog ? env->NewStringUTF(catalog->c_str()) : nullptr;
+  jstring jSchemaPattern =
+      schemaPattern ? env->NewStringUTF(schemaPattern->c_str()) : nullptr;
   jstring jTableNamePattern = env->NewStringUTF(tableNamePattern.c_str());
   jstring jColumnNamePattern = env->NewStringUTF(columnNamePattern.c_str());
 

--- a/src/odbc/src/odbc.cpp
+++ b/src/odbc/src/odbc.cpp
@@ -632,6 +632,7 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
                     SQLSMALLINT tableTypeLen) {
   using odbc::Statement;
   using odbc::utility::SqlStringToString;
+  using odbc::utility::SqlStringToOptString;
 
   LOG_DEBUG_MSG("SQLTables called");
 
@@ -644,10 +645,10 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
     return SQL_INVALID_HANDLE;
   }
 
-  std::string catalog = SqlStringToString(catalogName, catalogNameLen);
-  std::string schema = SqlStringToString(schemaName, schemaNameLen);
+  boost::optional< std::string > catalog = SqlStringToOptString(catalogName, catalogNameLen);
+  boost::optional< std::string > schema = SqlStringToOptString(schemaName, schemaNameLen);
   std::string table = SqlStringToString(tableName, tableNameLen);
-  std::string tableTypeStr = SqlStringToString(tableType, tableTypeLen);
+  boost::optional< std::string > tableTypeStr = SqlStringToOptString(tableType, tableTypeLen);
 
   LOG_INFO_MSG("catalog: " << catalog);
   LOG_INFO_MSG("schema: " << schema);
@@ -668,6 +669,7 @@ SQLRETURN SQLColumns(SQLHSTMT stmt, SQLCHAR* catalogName,
                      SQLSMALLINT columnNameLen) {
   using odbc::Statement;
   using odbc::utility::SqlStringToString;
+  using odbc::utility::SqlStringToOptString;
 
   LOG_DEBUG_MSG("SQLColumns called");
 
@@ -680,13 +682,15 @@ SQLRETURN SQLColumns(SQLHSTMT stmt, SQLCHAR* catalogName,
     return SQL_INVALID_HANDLE;
   }
 
-  std::string catalog = SqlStringToString(catalogName, catalogNameLen);
-  std::string schema = SqlStringToString(schemaName, schemaNameLen);
+  const boost::optional< std::string > catalog =
+      SqlStringToOptString(catalogName, catalogNameLen);
+  const boost::optional< std::string > schema =
+      SqlStringToOptString(schemaName, schemaNameLen);
   std::string table = SqlStringToString(tableName, tableNameLen);
   std::string column = SqlStringToString(columnName, columnNameLen);
 
-  LOG_INFO_MSG("catalog: " << catalog);
-  LOG_INFO_MSG("schema: " << schema);
+  LOG_INFO_MSG("catalog: " << catalog.get_value_or(""));
+  LOG_INFO_MSG("schema: " << schema.get_value_or(""));
   LOG_INFO_MSG("table: " << table);
   LOG_INFO_MSG("column: " << column);
 

--- a/src/odbc/src/query/column_metadata_query.cpp
+++ b/src/odbc/src/query/column_metadata_query.cpp
@@ -103,8 +103,8 @@ namespace odbc {
 namespace query {
 ColumnMetadataQuery::ColumnMetadataQuery(diagnostic::DiagnosableAdapter& diag,
                                          Connection& connection,
-                                         const std::string& catalog,
-                                         const std::string& schema,
+                                         const boost::optional< std::string >& catalog,
+                                         const boost::optional< std::string >& schema,
                                          const std::string& table,
                                          const std::string& column)
     : Query(diag, QueryType::COLUMN_METADATA),

--- a/src/odbc/src/query/table_metadata_query.cpp
+++ b/src/odbc/src/query/table_metadata_query.cpp
@@ -62,10 +62,10 @@ namespace odbc {
 namespace query {
 TableMetadataQuery::TableMetadataQuery(diagnostic::DiagnosableAdapter& diag,
                                        Connection& connection,
-                                       const std::string& catalog,
-                                       const std::string& schema,
+                                       const boost::optional< std::string >& catalog,
+                                       const boost::optional< std::string >& schema,
                                        const std::string& table,
-                                       const std::string& tableType)
+                                       const boost::optional< std::string >& tableType)
     : Query(diag, QueryType::TABLE_METADATA),
       connection(connection),
       catalog(catalog),
@@ -229,15 +229,19 @@ SqlResult::Type TableMetadataQuery::MakeRequestGetTablesMeta() {
     return SqlResult::AI_ERROR;
   }
 
-  std::vector< std::string > types;
-  if (tableType.empty()) {
-    types.emplace_back("TABLE");
-  } else {
-    std::stringstream ss(tableType);
-    std::string singleTableType;
-    while (std::getline(ss, singleTableType, ',')) {
-      types.push_back(dequote(trim(singleTableType)));
+  boost::optional< std::vector< std::string > > types = boost::none;
+  if (tableType) {
+    std::vector< std::string > typesArr;
+    if (tableType->empty()) {
+      typesArr.emplace_back("TABLE");
+    } else {
+      std::stringstream ss(*tableType);
+      std::string singleTableType;
+      while (std::getline(ss, singleTableType, ',')) {
+        typesArr.push_back(dequote(trim(singleTableType)));
+      }
     }
+    types = typesArr;
   }
 
   JniErrorInfo errInfo;

--- a/src/odbc/src/statement.cpp
+++ b/src/odbc/src/statement.cpp
@@ -649,8 +649,8 @@ SqlResult::Type Statement::InternalExecuteSqlQuery() {
   return currentQuery->Execute();
 }
 
-void Statement::ExecuteGetColumnsMetaQuery(const std::string& catalog,
-                                           const std::string& schema,
+void Statement::ExecuteGetColumnsMetaQuery(const boost::optional< std::string >& catalog,
+                                           const boost::optional< std::string >& schema,
                                            const std::string& table,
                                            const std::string& column) {
   IGNITE_ODBC_API_CALL(
@@ -658,12 +658,13 @@ void Statement::ExecuteGetColumnsMetaQuery(const std::string& catalog,
 }
 
 SqlResult::Type Statement::InternalExecuteGetColumnsMetaQuery(
-    const std::string& catalog, const std::string& schema,
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schema,
     const std::string& table, const std::string& column) {
   if (currentQuery.get())
     currentQuery->Close();
 
-  std::string schema0(schema);
+  std::string schema0(schema.get_value_or(""));
 
   if (schema0.empty())
     schema0 = connection.GetSchema();
@@ -674,17 +675,18 @@ SqlResult::Type Statement::InternalExecuteGetColumnsMetaQuery(
   return currentQuery->Execute();
 }
 
-void Statement::ExecuteGetTablesMetaQuery(const std::string& catalog,
-                                          const std::string& schema,
+void Statement::ExecuteGetTablesMetaQuery(const boost::optional< std::string >& catalog,
+                                          const boost::optional< std::string >& schema,
                                           const std::string& table,
-                                          const std::string& tableType) {
+                                          const boost::optional< std::string >& tableType) {
   IGNITE_ODBC_API_CALL(
       InternalExecuteGetTablesMetaQuery(catalog, schema, table, tableType));
 }
 
 SqlResult::Type Statement::InternalExecuteGetTablesMetaQuery(
-    const std::string& catalog, const std::string& schema,
-    const std::string& table, const std::string& tableType) {
+    const boost::optional< std::string >& catalog,
+    const boost::optional< std::string >& schema, const std::string& table,
+    const boost::optional< std::string >& tableType) {
   if (currentQuery.get())
     currentQuery->Close();
 


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
make changes so getColumns/getTables tests pass nullptr to JDBC

### Description

<!--- Details of what you changed -->
Make getColumns pass nullptr to JDBC when ODBC receives nullptr as parameter.
### Related Issue

<!--- Link to issue where this is tracked -->
https://bitquill.atlassian.net/browse/AD-751
### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm 
@RoyZhang2022 
<!-- Any additional reviewers -->
