### PR TITLE
[AD-771] fix issue of JDBC not returning tables

### DIFF
--- a/src/odbc/include/ignite/odbc.h
+++ b/src/odbc/include/ignite/odbc.h
@@ -89,15 +89,12 @@ SQLRETURN SQLExtendedFetch(SQLHSTMT stmt, SQLUSMALLINT orientation,
 
 SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* columnNum);
 
-/** If NULL tableName is passed, it will automatically be converted to "%". */
 SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
                     SQLSMALLINT catalogNameLen, SQLCHAR* schemaName,
                     SQLSMALLINT schemaNameLen, SQLCHAR* tableName,
                     SQLSMALLINT tableNameLen, SQLCHAR* tableType,
                     SQLSMALLINT tableTypeLen);
 
-/** If NULL tableName is passed, it will automatically be converted to "%".
-* If NULL columnName is passed, it will automatically be converted to "%". */
 SQLRETURN SQLColumns(SQLHSTMT stmt, SQLCHAR* catalogName,
                      SQLSMALLINT catalogNameLen, SQLCHAR* schemaName,
                      SQLSMALLINT schemaNameLen, SQLCHAR* tableName,

--- a/src/odbc/src/odbc.cpp
+++ b/src/odbc/src/odbc.cpp
@@ -625,6 +625,7 @@ SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* columnNum) {
   return statement->GetDiagnosticRecords().GetReturnCode();
 }
 
+/** If NULL tableName is passed, it will automatically be converted to "%". */
 SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
                     SQLSMALLINT catalogNameLen, SQLCHAR* schemaName,
                     SQLSMALLINT schemaNameLen, SQLCHAR* tableName,
@@ -646,8 +647,7 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
 
   boost::optional< std::string > catalog = SqlStringToOptString(catalogName, catalogNameLen);
   boost::optional< std::string > schema = SqlStringToOptString(schemaName, schemaNameLen);
-  boost::optional< std::string > tableTmp = SqlStringToOptString(tableName, tableNameLen);
-  std::string table = tableTmp ? *tableTmp : std::string("%");
+  std::string table = SqlStringToOptString(tableName, tableNameLen).get_value_or("%");
   boost::optional< std::string > tableTypeStr = SqlStringToOptString(tableType, tableTypeLen);
 
   LOG_INFO_MSG("catalog: " << catalog);
@@ -662,6 +662,8 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLCHAR* catalogName,
   return statement->GetDiagnosticRecords().GetReturnCode();
 }
 
+/** If NULL tableName is passed, it will automatically be converted to "%".
+ * If NULL columnName is passed, it will automatically be converted to "%". */
 SQLRETURN SQLColumns(SQLHSTMT stmt, SQLCHAR* catalogName,
                      SQLSMALLINT catalogNameLen, SQLCHAR* schemaName,
                      SQLSMALLINT schemaNameLen, SQLCHAR* tableName,
@@ -685,12 +687,10 @@ SQLRETURN SQLColumns(SQLHSTMT stmt, SQLCHAR* catalogName,
       SqlStringToOptString(catalogName, catalogNameLen);
   boost::optional< std::string > schema =
       SqlStringToOptString(schemaName, schemaNameLen);
-  boost::optional< std::string > tableTmp =
-      SqlStringToOptString(tableName, tableNameLen);
-  std::string table = tableTmp ? *tableTmp : std::string("%");
-  boost::optional< std::string > columnTmp =
-      SqlStringToOptString(columnName, columnNameLen);
-  std::string column = columnTmp ? *columnTmp : std::string("%");
+  std::string table =
+      SqlStringToOptString(tableName, tableNameLen).get_value_or("%");
+  std::string column =
+      SqlStringToOptString(columnName, columnNameLen).get_value_or("%");
 
   LOG_INFO_MSG("catalog: " << catalog.get_value_or(""));
   LOG_INFO_MSG("schema: " << schema.get_value_or(""));


### PR DESCRIPTION
### Summary

<!--- General summary / title -->
Make JDBC return tables/columns to ODBC
### Description

<!--- Details of what you changed -->
* Tableau passes catalog, schema, table name, and table type as null pointers to SQLTables.
PowerBI passes catalog, schema, and table name as null pointers to SQLTables.

PowerBI passes column name as null pointers to SQLColumns.

Therefore, if null is passed in ODBC as table pattern, "%" needs to be passed as table pattern to JDBC.
Same thing with null being passed to ODBC as column name pattern.
### Related Issue

<!--- Link to issue where this is tracked -->
https://bitquill.atlassian.net/browse/AD-771
### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->
