### PR TITLE
[AD-572] iODBC port (driver is using unixodbc)

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -28,6 +28,7 @@ env:
   DOC_DB_LOG_PATH: "${{github.workspace}}/build/odbc/logs"
   DOC_DB_LOG_LEVEL: "debug"
   JDBC_DRIVER_VERSION: "1.2.4"
+  ODBCINSTINI: "${{github.workspace}}/build/odbc/lib/ignite-odbc-install.ini"
 
 jobs:
   build-mac:
@@ -59,7 +60,8 @@ jobs:
     - name: get-dependencies
       run: |
         brew tap homebrew/services
-        brew install unixodbc
+        brew unlink unixodbc
+        brew install libiodbc
         brew install cmake
         brew install openssl
         brew install boost

--- a/scripts/register_driver_unix.sh
+++ b/scripts/register_driver_unix.sh
@@ -30,4 +30,9 @@ echo "Setup=$ODBC_LIB_FILENAME"  >> "$ODBC_LIB_PATH/ignite-odbc-install.ini"
 echo "DriverODBCVer=03.00"       >> "$ODBC_LIB_PATH/ignite-odbc-install.ini"
 echo "FileUsage=0"               >> "$ODBC_LIB_PATH/ignite-odbc-install.ini"
 
-odbcinst -i -d -f "$ODBC_LIB_PATH/ignite-odbc-install.ini"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  odbcinst -i -d -f "$ODBC_LIB_PATH/ignite-odbc-install.ini"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  export ODBCINSTINI="$ODBC_LIB_PATH/ignite-odbc-install.ini"
+  echo "Exported ODBCINSTINI=$ODBCINSTINI"
+fi

--- a/src/DEVNOTES.txt
+++ b/src/DEVNOTES.txt
@@ -32,7 +32,8 @@ Thin-client module is disabled by default, you can enable it by setting CMake op
 
 ODBC module requirements:
  * OpenSSL, 1.0 or later
- * UnixODBC on Linux or Mac OS X
+ * UnixODBC on Linux
+ * iODBC on Mac OS X
 
 ODBC module is disabled by default, you can enable it by setting CMake option -DWITH_ODBC=ON.
 OPENSSL_ROOT_DIR environment variable must be set to openssl installation directory on Windows, on other platforms

--- a/src/markdown/setup/developer-guide.md
+++ b/src/markdown/setup/developer-guide.md
@@ -101,8 +101,8 @@ Example:
 1. Install dependencies
    1. `brew install cmake`
    2. `brew install openssl`
-   3. `brew install unixodbc`  
-      - You may need to unlink `libiodbc` if you already have this installed. Use `brew unlink libiodbc`.
+   3. `brew install libiodbc`  
+      - You may need to unlink `unixodbc` if you already have this installed. Use `brew unlink unixodbc`.
    4. `brew install boost`
    5. Install MongoDB using [`MongoDB's Installation Guide for MongoDB Community Edition on macOS`](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/).
    6. `brew install mongo-cxx-driver`
@@ -121,10 +121,11 @@ Example:
    1. E.g.: `./build_mac_release64.sh`
    2. Navigate to the `build/odbc/lib` folder to use the generated files.
 3. Set the environment variable `DOCUMENTDB_HOME`. On a developer's machine, set it to `<repo-folder>/build/odbc/bin`
-4. Run the following command to register the ODBC driver. 
-   `./scripts/register_driver_unix.sh`
-5. Now you're ready to run the tests (e.g., `./build/odbc/bin/ignite-odbc-tests  --catch_system_errors=false`).
-6. More details in [`src\DEVNOTES.txt`](src/DEVNOTES.txt).
+4. Set the environment variable `ODBCINSTINI`. On a developer's machine, set it to `<repo-folder>/build/odbc/lib/ignite-odbc-install.ini`.
+5. Run the following command to register the ODBC driver. 
+   `./scripts/register_driver_unix.sh`.
+6. Now you're ready to run the tests (e.g., `./build/odbc/bin/ignite-odbc-tests  --catch_system_errors=false`).
+7. More details in [`src\DEVNOTES.txt`](src/DEVNOTES.txt).
 
 ## Linux
 
@@ -229,16 +230,3 @@ There are two ways to fix the issue.
       E.g. If is in another docker container `export LOCAL_DATABASE_HOST=<ip from the mongo docker container>` or if is your host machine `export LOCAL_DATABASE_HOST=host.docker.internal`.
    9. You are ready to run the tests.
       E.g. `/documentdb-odbc/build/odbc/bin/ignite-odbc-tests --catch_system_errors=false`.
-
-
-## Troubleshooting 
-
-### Issue: MacOS build fails with error about iODBC header
-#### Example error message  
-```
-/Library/Frameworks/iODBC.framework/Headers/sqlext.h:82:10: fatal error: 'iODBC/sql.h' file not found
-#include <iODBC/sql.h>
-     ^~~~~~~~~~~~~ 
-``` 
-#### Fix 
-If you have installed the iODBC Driver Manager, the headers installed with it might be used instead of those from `unixodbc`. You may need to uninstall this driver manager and remove the `/Library/Frameworks/iODBC.framework/` directory. 

--- a/src/markdown/support/unicode-support.md
+++ b/src/markdown/support/unicode-support.md
@@ -8,7 +8,7 @@ The definition of the Unicode at the ODBC layer is defined as SQLWCHAR. There ar
 
 - *Windows*: The SQLWCHAR is defined as wchar_t (2-byte)
 - *MacOS (iODBC)*: The SQLWCHAR is defined as wchar_t (4-byte)
-- *Linux (unixODBC)*: The SQLWCHAR is defined as unsigned short (2-byte) or wchar_t (4-byte)
+- *Linux (unixODBC)*: The SQLWCHAR is defined as unsigned short (2-byte)
 
 In terms of our driver, the entry point is the entry_point.cpp/h. For each API entry point, it calls the equivalent in the `odbc` namespace.
 

--- a/src/odbc-test/src/meta_queries_test.cpp
+++ b/src/odbc-test/src/meta_queries_test.cpp
@@ -16,7 +16,13 @@
  */
 
 #ifdef _WIN32
-#include <windows.h>
+#include <Windows.h>
+#endif
+
+#ifdef __APPLE__
+constexpr auto FUNCTION_SEQUENCE_ERROR_STATE = "S1010";
+#else
+constexpr auto FUNCTION_SEQUENCE_ERROR_STATE = "24000";
 #endif
 
 #include <sql.h>
@@ -121,7 +127,8 @@ struct MetaQueriesTestSuiteFixture : public odbc::OdbcTestSuite {
     ret = SQLGetData(stmt, 1, SQL_C_CHAR, buf, sizeof(buf), &bufLen);
 
     BOOST_REQUIRE_EQUAL(ret, SQL_ERROR);
-    BOOST_CHECK_EQUAL(GetOdbcErrorState(SQL_HANDLE_STMT, stmt), "24000");
+    BOOST_CHECK_EQUAL(GetOdbcErrorState(SQL_HANDLE_STMT, stmt),
+                      FUNCTION_SEQUENCE_ERROR_STATE);
   }
 
   /**

--- a/src/odbc-test/src/utility_test.cpp
+++ b/src/odbc-test/src/utility_test.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(TestUtilityCopyStringToBuffer) {
   bytesWrittenOrRequired =
       CopyStringToBuffer(str, buffer, ((10 + 1) * sizeof(SQLWCHAR)), true);
   BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), ToUtf8(wstr.substr(0, 10)));
-  BOOST_CHECK_EQUAL(20, bytesWrittenOrRequired);
+  BOOST_CHECK_EQUAL(10 * sizeof(SQLWCHAR), bytesWrittenOrRequired);
 
   // Zero length buffer in character mode.
   buffer[0] = 0;

--- a/src/odbc/src/config/connection_info.cpp
+++ b/src/odbc/src/config/connection_info.cpp
@@ -36,6 +36,13 @@
 #define SQL_ASYNC_NOTIFICATION_CAPABLE 0x00000001L
 #endif
 
+// Missing definition in iODBC sqlext.h
+#if (ODBCVER >= 0x0300)
+#ifndef SQL_CVT_GUID
+#define SQL_CVT_GUID 0x01000000L
+#endif
+#endif
+
 namespace ignite {
 namespace odbc {
 namespace config {


### PR DESCRIPTION
### Summary

[AD-572] iODBC port (driver is using unixodbc)

### Description

- [x] Change Mac OS install to use iODBC instead of unixODBC.

### Related Issue

https://bitquill.atlassian.net/browse/AD-572

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
