### PR TITLE
[AD-803] and [AD-811]

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -149,6 +149,7 @@ jobs:
         ./src/odbc-test/scripts/import_test_data.sh
 
     - name: run-tests
+      id: runtests
       run: |
         mkdir -p "${{env.DOC_DB_LOG_PATH}}"
         ssh -f -N -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${{env.DOC_DB_PRIV_KEY_FILE}} -L${{env.DOC_DB_LOCAL_PORT}}:${{secrets.DOC_DB_HOST}}:${{env.DOC_DB_REMOTE_PORT}} ${{secrets.DOC_DB_USER}}
@@ -162,7 +163,7 @@ jobs:
         comment_title: "Ubuntu 20.04 Build Unit Test Results"
         files: ./odbc_test_result.xml
     - name: upload-test-file
-      if: always()
+      if: always() && (steps.runtests.outcome == 'failure')
       uses: actions/upload-artifact@v2
       with:
         name: odbc-test-results

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -111,6 +111,7 @@ jobs:
         chmod +x ./src/odbc-test/scripts/import_test_data.sh
         ./src/odbc-test/scripts/import_test_data.sh
     - name: run-tests
+      id: runtests
       run: |
         mkdir -p "${{env.DOC_DB_LOG_PATH}}"
         ssh -f -N -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${{env.DOC_DB_PRIV_KEY_FILE}} -L${{env.DOC_DB_LOCAL_PORT}}:${{secrets.DOC_DB_HOST}}:${{env.DOC_DB_REMOTE_PORT}} ${{secrets.DOC_DB_USER}}
@@ -123,7 +124,7 @@ jobs:
         comment_title: "MacOS Big Sur 11 Build Unit Test Results"
         files: ./odbc_test_result.xml
     - name: upload-test-file
-      if: always()
+      if: always() && (steps.runtests.outcome == 'failure')
       uses: actions/upload-artifact@v2
       with:
         name: odbc-test-results

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -134,6 +134,7 @@ jobs:
         ./src/odbc-test/scripts/import_test_data.ps1
 
     - name: run-tests
+      id: runtests
       run: |
         mkdir -p "${{env.DOC_DB_LOG_PATH}}"
         Start-Process -NoNewWindow ssh "-f -N -o UserKnownHostsFile=/temp -o StrictHostKeyChecking=no -i ${{env.DOC_DB_PRIV_KEY_FILE}} -L${{env.DOC_DB_LOCAL_PORT}}:${{secrets.DOC_DB_HOST}}:${{env.DOC_DB_REMOTE_PORT}} ${{secrets.DOC_DB_USER}}"
@@ -148,7 +149,7 @@ jobs:
         files: ./odbc_test_result.xml
 
     - name: upload-test-file
-      if: always()
+      if: always() && (steps.runtests.outcome == 'failure')
       uses: actions/upload-artifact@v2
       with:
         name: odbc-test-results

--- a/src/odbc-test/CMakeLists.txt
+++ b/src/odbc-test/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 
 set(SOURCES 
          src/api_robustness_test.cpp
+         src/application_data_buffer_test.cpp
          src/column_meta_test.cpp
          src/configuration_test.cpp
          src/connection_test.cpp

--- a/src/odbc-test/src/application_data_buffer_test.cpp
+++ b/src/odbc-test/src/application_data_buffer_test.cpp
@@ -25,12 +25,11 @@
 
 #define FLOAT_PRECISION 0.0000001f
 
+using namespace boost::unit_test;
 using namespace ignite;
 using namespace ignite::odbc;
 using namespace ignite::odbc::app;
 using namespace ignite::odbc::type_traits;
-
-using ignite::impl::binary::BinaryUtils;
 
 BOOST_AUTO_TEST_SUITE(ApplicationDataBufferTestSuite)
 
@@ -64,6 +63,58 @@ BOOST_AUTO_TEST_CASE(TestPutIntToString) {
   appBuf.PutInt32(-1234567);
   BOOST_CHECK(!strcmp(buffer, "-1234567"));
   BOOST_CHECK(reslen == strlen("-1234567"));
+
+  std::string intMaxStr = std::to_string(INT64_MAX);
+  appBuf.PutInt64(INT64_MAX);
+  BOOST_CHECK(!strcmp(buffer, intMaxStr.c_str()));
+  BOOST_CHECK(reslen == intMaxStr.size());
+
+  std::string intMinStr = std::to_string(INT64_MIN);
+  appBuf.PutInt64(INT64_MIN);
+  BOOST_CHECK(!strcmp(buffer, intMinStr.c_str()));
+  BOOST_CHECK(reslen == intMinStr.size());
+}
+
+BOOST_AUTO_TEST_CASE(TestPutIntToWString) {
+  SQLWCHAR buffer[1024];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
+                               &reslen);
+
+  appBuf.PutInt8(12);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "12");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("12"));
+
+  appBuf.PutInt8(-12);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "-12");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("-12"));
+
+  appBuf.PutInt16(9876);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "9876");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("9876"));
+
+  appBuf.PutInt16(-9876);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "-9876");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("-9876"));
+
+  appBuf.PutInt32(1234567);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "1234567");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("1234567"));
+
+  appBuf.PutInt32(-1234567);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "-1234567");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("-1234567"));
+
+  std::string intMaxStr = std::to_string(INT64_MAX);
+  appBuf.PutInt64(INT64_MAX);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == intMaxStr);
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == intMaxStr.size());
+
+  std::string intMinStr = std::to_string(INT64_MIN);
+  appBuf.PutInt64(INT64_MIN);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == intMinStr);
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == intMinStr.size());
 }
 
 BOOST_AUTO_TEST_CASE(TestPutFloatToString) {
@@ -90,6 +141,30 @@ BOOST_AUTO_TEST_CASE(TestPutFloatToString) {
   BOOST_CHECK(reslen == strlen("-1000.21"));
 }
 
+BOOST_AUTO_TEST_CASE(TestPutFloatToWString) {
+  SQLWCHAR buffer[1024];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
+                               &reslen);
+
+  appBuf.PutFloat(12.42f);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "12.42");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("12.42"));
+
+  appBuf.PutFloat(-12.42f);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "-12.42");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("-12.42"));
+
+  appBuf.PutDouble(1000.21);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "1000.21");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("1000.21"));
+
+  appBuf.PutDouble(-1000.21);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "-1000.21");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("-1000.21"));
+}
+
 BOOST_AUTO_TEST_CASE(TestPutGuidToString) {
   char buffer[1024];
   SqlLen reslen = 0;
@@ -97,12 +172,28 @@ BOOST_AUTO_TEST_CASE(TestPutGuidToString) {
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, buffer, sizeof(buffer),
                                &reslen);
 
-  ignite::Guid guid(0x1da1ef8f39ff4d62UL, 0x8b72e8e9f3371801UL);
+  Guid guid(0x1da1ef8f39ff4d62UL, 0x8b72e8e9f3371801UL);
 
   appBuf.PutGuid(guid);
 
   BOOST_CHECK(!strcmp(buffer, "1da1ef8f-39ff-4d62-8b72-e8e9f3371801"));
   BOOST_CHECK(reslen == strlen("1da1ef8f-39ff-4d62-8b72-e8e9f3371801"));
+}
+
+BOOST_AUTO_TEST_CASE(TestPutGuidToWString) {
+  SQLWCHAR buffer[1024];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
+                               &reslen);
+
+  Guid guid(0x1da1ef8f39ff4d62UL, 0x8b72e8e9f3371801UL);
+
+  appBuf.PutGuid(guid);
+
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "1da1ef8f-39ff-4d62-8b72-e8e9f3371801");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR))
+              == strlen("1da1ef8f-39ff-4d62-8b72-e8e9f3371801"));
 }
 
 BOOST_AUTO_TEST_CASE(TestPutBinaryToString) {
@@ -122,6 +213,24 @@ BOOST_AUTO_TEST_CASE(TestPutBinaryToString) {
   BOOST_CHECK(reslen == strlen("2184f4dc0100fff0"));
 }
 
+BOOST_AUTO_TEST_CASE(TestPutBinaryToWString) {
+  SQLWCHAR buffer[1024];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
+                               &reslen);
+
+  uint8_t binary[] = {0x21, 0x84, 0xF4, 0xDC, 0x01, 0x00, 0xFF, 0xF0};
+
+  int32_t written = 0;
+
+  appBuf.PutBinaryData(binary, sizeof(binary), written);
+
+  std::string bufferAsString = utility::SqlWcharToString(buffer);
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "2184f4dc0100fff0");
+  BOOST_CHECK((reslen / sizeof(SQLWCHAR)) == strlen("2184f4dc0100fff0"));
+}
+
 BOOST_AUTO_TEST_CASE(TestPutStringToString) {
   char buffer[1024];
   SqlLen reslen = 0;
@@ -138,7 +247,7 @@ BOOST_AUTO_TEST_CASE(TestPutStringToString) {
 }
 
 BOOST_AUTO_TEST_CASE(TestPutStringToWstring) {
-  wchar_t buffer[1024];
+  SQLWCHAR buffer[1024];
   SqlLen reslen = 0;
 
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer, sizeof(buffer),
@@ -147,7 +256,7 @@ BOOST_AUTO_TEST_CASE(TestPutStringToWstring) {
   std::string testString("Test string");
 
   appBuf.PutString(testString);
-  BOOST_CHECK(!wcscmp(buffer, L"Test string"));
+  BOOST_CHECK(utility::SqlWcharToString(buffer) == "Test string");
 }
 
 BOOST_AUTO_TEST_CASE(TestPutStringToLong) {
@@ -322,6 +431,33 @@ BOOST_AUTO_TEST_CASE(TestPutDecimalToString) {
   BOOST_CHECK(std::string(strBuf, reslen) == "-53.5");
 }
 
+BOOST_AUTO_TEST_CASE(TestPutDecimalToWString) {
+  SQLWCHAR strBuf[64];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, &strBuf,
+                               sizeof(strBuf), &reslen);
+
+  common::Decimal decimal;
+
+  appBuf.PutDecimal(decimal);
+  BOOST_CHECK(utility::SqlWcharToString(strBuf) == "0");
+
+  int8_t mag1[] = {1, 0};
+
+  decimal = common::Decimal(mag1, sizeof(mag1), 0, 1);
+
+  appBuf.PutDecimal(decimal);
+  BOOST_CHECK(utility::SqlWcharToString(strBuf) == "256");
+
+  int8_t mag2[] = {2, 23};
+
+  decimal = common::Decimal(mag2, sizeof(mag2), 1, -1);
+
+  appBuf.PutDecimal(decimal);
+  BOOST_CHECK(utility::SqlWcharToString(strBuf) == "-53.5");
+}
+
 BOOST_AUTO_TEST_CASE(TestPutDecimalToNumeric) {
   SQL_NUMERIC_STRUCT buf;
   SqlLen reslen = 0;
@@ -395,6 +531,20 @@ BOOST_AUTO_TEST_CASE(TestPutDateToString) {
   BOOST_CHECK_EQUAL(std::string(strBuf, reslen), std::string("1999-02-22"));
 }
 
+BOOST_AUTO_TEST_CASE(TestPutDateToWString) {
+  SQLWCHAR strBuf[64];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, &strBuf, sizeof(strBuf),
+                               &reslen);
+
+  Date date = common::MakeDateGmt(1999, 2, 22);
+
+  appBuf.PutDate(date);
+
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(strBuf), std::string("1999-02-22"));
+}
+
 BOOST_AUTO_TEST_CASE(TestPutDateToDate) {
   SQL_DATE_STRUCT buf;
   SqlLen reslen = sizeof(buf);
@@ -446,6 +596,20 @@ BOOST_AUTO_TEST_CASE(TestPutTimeToString) {
   BOOST_CHECK_EQUAL(std::string(strBuf, reslen), std::string("07:15:00"));
 }
 
+BOOST_AUTO_TEST_CASE(TestPutTimeToWString) {
+  SQLWCHAR strBuf[64];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, &strBuf, sizeof(strBuf),
+                               &reslen);
+
+  Time time = common::MakeTimeGmt(7, 15, 0);
+
+  appBuf.PutTime(time);
+
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(strBuf), std::string("07:15:00"));
+}
+
 BOOST_AUTO_TEST_CASE(TestPutTimeToTime) {
   SQL_TIME_STRUCT buf;
   SqlLen reslen = sizeof(buf);
@@ -474,6 +638,21 @@ BOOST_AUTO_TEST_CASE(TestPutTimestampToString) {
   appBuf.PutTimestamp(date);
 
   BOOST_CHECK_EQUAL(std::string(strBuf, reslen),
+                    std::string("2018-11-01 17:45:59"));
+}
+
+BOOST_AUTO_TEST_CASE(TestPutTimestampToWString) {
+  SQLWCHAR strBuf[64];
+  SqlLen reslen = 0;
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, &strBuf, sizeof(strBuf),
+                               &reslen);
+
+  Timestamp date = common::MakeTimestampGmt(2018, 11, 1, 17, 45, 59);
+
+  appBuf.PutTimestamp(date);
+
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(strBuf),
                     std::string("2018-11-01 17:45:59"));
 }
 
@@ -536,7 +715,20 @@ BOOST_AUTO_TEST_CASE(TestGetGuidFromString) {
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, buffer,
                                sizeof(buffer) - 1, &reslen);
 
-  ignite::Guid guid = appBuf.GetGuid();
+  Guid guid = appBuf.GetGuid();
+
+  BOOST_CHECK_EQUAL(guid, Guid(0x1da1ef8f39ff4d62UL, 0x8b72e8e9f3371801UL));
+}
+
+BOOST_AUTO_TEST_CASE(TestGetGuidFromWString) {
+  std::vector< SQLWCHAR > buffer =
+      utility::ToWCHARVector("1da1ef8f-39ff-4d62-8b72-e8e9f3371801");
+  SqlLen reslen = buffer.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buffer.data(),
+                               buffer.size() * sizeof(SQLWCHAR), &reslen);
+
+  Guid guid = appBuf.GetGuid();
 
   BOOST_CHECK_EQUAL(guid, Guid(0x1da1ef8f39ff4d62UL, 0x8b72e8e9f3371801UL));
 }
@@ -588,6 +780,18 @@ BOOST_AUTO_TEST_CASE(TestGetStringFromString) {
   BOOST_CHECK(res.compare(buf));
 }
 
+BOOST_AUTO_TEST_CASE(TestGetStringFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("Some data 32d2d5hs");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
+                               &reslen);
+
+  std::string res = appBuf.GetString(reslen);
+
+  BOOST_CHECK(utility::SqlWcharToString(buf.data()) == res);
+}
+
 BOOST_AUTO_TEST_CASE(TestGetFloatFromUshort) {
   unsigned short numBuf = 7162;
   SqlLen reslen = sizeof(numBuf);
@@ -609,6 +813,22 @@ BOOST_AUTO_TEST_CASE(TestGetFloatFromString) {
   SqlLen reslen = sizeof(buf);
 
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, &buf, reslen, &reslen);
+
+  float resFloat = appBuf.GetFloat();
+
+  BOOST_CHECK_CLOSE_FRACTION(resFloat, 28.562f, FLOAT_PRECISION);
+
+  double resDouble = appBuf.GetDouble();
+
+  BOOST_CHECK_CLOSE_FRACTION(resDouble, 28.562, FLOAT_PRECISION);
+}
+
+BOOST_AUTO_TEST_CASE(TestGetFloatFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("28.562");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
+                               &reslen);
 
   float resFloat = appBuf.GetFloat();
 
@@ -655,6 +875,30 @@ BOOST_AUTO_TEST_CASE(TestGetIntFromString) {
   SqlLen reslen = sizeof(buf);
 
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, &buf, reslen, &reslen);
+
+  int64_t resInt64 = appBuf.GetInt64();
+
+  BOOST_CHECK(resInt64 == 39);
+
+  int32_t resInt32 = appBuf.GetInt32();
+
+  BOOST_CHECK(resInt32 == 39);
+
+  int16_t resInt16 = appBuf.GetInt16();
+
+  BOOST_CHECK(resInt16 == 39);
+
+  int8_t resInt8 = appBuf.GetInt8();
+
+  BOOST_CHECK(resInt8 == 39);
+}
+
+BOOST_AUTO_TEST_CASE(TestGetIntFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("39");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
+                               &reslen);
 
   int64_t resInt64 = appBuf.GetInt64();
 
@@ -832,6 +1076,29 @@ BOOST_AUTO_TEST_CASE(TestGetDateFromString) {
   BOOST_CHECK_EQUAL(0, tmDate.tm_sec);
 }
 
+BOOST_AUTO_TEST_CASE(TestGetDateFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("1999-02-22");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
+                               &reslen);
+
+  Date date = appBuf.GetDate();
+
+  tm tmDate;
+
+  bool success = common::DateToCTm(date, tmDate);
+
+  BOOST_REQUIRE(success);
+
+  BOOST_CHECK_EQUAL(1999, tmDate.tm_year + 1900);
+  BOOST_CHECK_EQUAL(2, tmDate.tm_mon + 1);
+  BOOST_CHECK_EQUAL(22, tmDate.tm_mday);
+  BOOST_CHECK_EQUAL(0, tmDate.tm_hour);
+  BOOST_CHECK_EQUAL(0, tmDate.tm_min);
+  BOOST_CHECK_EQUAL(0, tmDate.tm_sec);
+}
+
 BOOST_AUTO_TEST_CASE(TestGetTimeFromString) {
   char buf[] = "17:5:59";
   SqlLen reslen = sizeof(buf);
@@ -855,11 +1122,57 @@ BOOST_AUTO_TEST_CASE(TestGetTimeFromString) {
   BOOST_CHECK_EQUAL(59, tmTime.tm_sec);
 }
 
+BOOST_AUTO_TEST_CASE(TestGetTimeFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("17:5:59");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
+                               &reslen);
+
+  Time time = appBuf.GetTime();
+
+  tm tmTime;
+
+  bool success = common::TimeToCTm(time, tmTime);
+
+  BOOST_REQUIRE(success);
+
+  BOOST_CHECK_EQUAL(1970, tmTime.tm_year + 1900);
+  BOOST_CHECK_EQUAL(1, tmTime.tm_mon + 1);
+  BOOST_CHECK_EQUAL(1, tmTime.tm_mday);
+  BOOST_CHECK_EQUAL(17, tmTime.tm_hour);
+  BOOST_CHECK_EQUAL(5, tmTime.tm_min);
+  BOOST_CHECK_EQUAL(59, tmTime.tm_sec);
+}
+
 BOOST_AUTO_TEST_CASE(TestGetTimestampFromString) {
   char buf[] = "2018-11-01 17:45:59";
   SqlLen reslen = sizeof(buf);
 
   ApplicationDataBuffer appBuf(OdbcNativeType::AI_CHAR, &buf[0], sizeof(buf),
+                               &reslen);
+
+  Timestamp date = appBuf.GetTimestamp();
+
+  tm tmDate;
+
+  bool success = common::TimestampToCTm(date, tmDate);
+
+  BOOST_REQUIRE(success);
+
+  BOOST_CHECK_EQUAL(2018, tmDate.tm_year + 1900);
+  BOOST_CHECK_EQUAL(11, tmDate.tm_mon + 1);
+  BOOST_CHECK_EQUAL(1, tmDate.tm_mday);
+  BOOST_CHECK_EQUAL(17, tmDate.tm_hour);
+  BOOST_CHECK_EQUAL(45, tmDate.tm_min);
+  BOOST_CHECK_EQUAL(59, tmDate.tm_sec);
+}
+
+BOOST_AUTO_TEST_CASE(TestGetTimestampFromWString) {
+  std::vector< SQLWCHAR > buf = utility::ToWCHARVector("2018-11-01 17:45:59");
+  SqlLen reslen = buf.size() * sizeof(SQLWCHAR);
+
+  ApplicationDataBuffer appBuf(OdbcNativeType::AI_WCHAR, buf.data(), reslen,
                                &reslen);
 
   Timestamp date = appBuf.GetTimestamp();

--- a/src/odbc-test/src/meta_queries_test.cpp
+++ b/src/odbc-test/src/meta_queries_test.cpp
@@ -115,7 +115,7 @@ struct MetaQueriesTestSuiteFixture : public odbc::OdbcTestSuite {
         BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
       if (i == columnIndex && !expectedValue.empty()) {
-        std::string actualValueStr = utility::SqlStringToString(buf, bufLen);
+        std::string actualValueStr = utility::SqlWcharToString(buf, bufLen);
         BOOST_CHECK_EQUAL(expectedValue, actualValueStr);
       }
     }
@@ -259,7 +259,7 @@ struct MetaQueriesTestSuiteFixture : public odbc::OdbcTestSuite {
     if (!SQL_SUCCEEDED(ret))
       BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-    std::string buf = utility::SqlStringToString(strBuf);
+    std::string buf = utility::SqlWcharToString(strBuf);
 
     BOOST_CHECK(expectedVal == buf);
   }
@@ -320,7 +320,7 @@ struct MetaQueriesTestSuiteFixture : public odbc::OdbcTestSuite {
     BOOST_CHECK_GE(nameLen, 0);
     BOOST_CHECK_LE(nameLen, static_cast< SQLSMALLINT >(ODBC_BUFFER_SIZE));
 
-    BOOST_CHECK_EQUAL(utility::SqlStringToString(name.data()), expName);
+    BOOST_CHECK_EQUAL(utility::SqlWcharToString(name.data()), expName);
     BOOST_CHECK_EQUAL(dataType, expDataType);
     BOOST_CHECK_EQUAL(size, expSize);
     BOOST_CHECK_EQUAL(scale, expScale);
@@ -443,7 +443,7 @@ struct MetaQueriesTestSuiteFixture : public odbc::OdbcTestSuite {
     BOOST_CHECK_GE(nameLen, 0);
     BOOST_CHECK_LE(nameLen, static_cast< SQLSMALLINT >(ODBC_BUFFER_SIZE));
 
-    BOOST_CHECK_EQUAL(utility::SqlStringToString(name.data()), expName);
+    BOOST_CHECK_EQUAL(utility::SqlWcharToString(name.data()), expName);
     BOOST_CHECK_EQUAL(dataType, expDataType);
     BOOST_CHECK_EQUAL(size, expSize);
     BOOST_CHECK_EQUAL(scale, expScale);
@@ -711,7 +711,7 @@ BOOST_AUTO_TEST_CASE(TestColAttributeDataTypesAndColumnNames) {
     if (!SQL_SUCCEEDED(ret))
       BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-    BOOST_CHECK_EQUAL(utility::SqlStringToString(strBuf), tests[i - 1].second);
+    BOOST_CHECK_EQUAL(utility::SqlWcharToString(strBuf), tests[i - 1].second);
   }
 }
 
@@ -1299,7 +1299,7 @@ BOOST_AUTO_TEST_CASE(TestGetDataWithTablesReturnsOne) {
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
   CheckSingleRowResultSetWithGetData(stmt, 3,
-                                     utility::SqlStringToString(table.data()));
+                                     utility::SqlWcharToString(table.data()));
 }
 
 BOOST_AUTO_TEST_CASE(TestGetDataWithTablesReturnsOneFromLocalServer) {
@@ -1988,7 +1988,7 @@ BOOST_AUTO_TEST_CASE(TestSQLColumnWithSQLBindCols) {
   if (!SQL_SUCCEEDED(ret)) {
     BOOST_ERROR(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
   }
-  BOOST_CHECK_EQUAL("TABLE_SCHEM", utility::SqlStringToString(
+  BOOST_CHECK_EQUAL("TABLE_SCHEM", utility::SqlWcharToString(
                                        attrColumnName, attrColumnNameLen));
 
   // Test that the next fetch will have no data.

--- a/src/odbc-test/src/queries_test.cpp
+++ b/src/odbc-test/src/queries_test.cpp
@@ -336,20 +336,20 @@ BOOST_AUTO_TEST_CASE(TestSingleResultUsingGetData) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d91892191475139",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDecimal128_len);
   BOOST_CHECK_EQUAL(
       "340282350000000000000",
-      utility::SqlStringToString(fieldDecimal128, fieldDecimal128_len, true));
+      utility::SqlWcharToString(fieldDecimal128, fieldDecimal128_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDouble_len);
   BOOST_CHECK_EQUAL(1.7976931348623157e308, fieldDouble);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldString_len);
-  BOOST_CHECK_EQUAL("some Text", utility::SqlStringToString(
+  BOOST_CHECK_EQUAL("some Text", utility::SqlWcharToString(
                                      fieldString, fieldString_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldObjectId_len);
   BOOST_CHECK_EQUAL(
       "62196dcc4d9189219147513a",
-      utility::SqlStringToString(fieldObjectId, fieldObjectId_len, true));
+      utility::SqlWcharToString(fieldObjectId, fieldObjectId_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldBoolean_len);
   BOOST_CHECK_EQUAL(true, fieldBoolean);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDate_len);
@@ -362,10 +362,10 @@ BOOST_AUTO_TEST_CASE(TestSingleResultUsingGetData) {
   BOOST_CHECK_EQUAL(9223372036854775807, fieldLong);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldMaxKey_len);
   BOOST_CHECK_EQUAL(
-      "MAXKEY", utility::SqlStringToString(fieldMaxKey, fieldMaxKey_len, true));
+      "MAXKEY", utility::SqlWcharToString(fieldMaxKey, fieldMaxKey_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldMinKey_len);
   BOOST_CHECK_EQUAL(
-      "MINKEY", utility::SqlStringToString(fieldMinKey, fieldMinKey_len, true));
+      "MINKEY", utility::SqlWcharToString(fieldMinKey, fieldMinKey_len, true));
   BOOST_CHECK_EQUAL(SQL_NULL_DATA, fieldNull_len);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldBinary_len);
   BOOST_CHECK_EQUAL(3, fieldBinary_len);
@@ -463,20 +463,20 @@ BOOST_AUTO_TEST_CASE(TestSingleResultUsingBindCol) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d91892191475139",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDecimal128_len);
   BOOST_CHECK_EQUAL(
       "340282350000000000000",
-      utility::SqlStringToString(fieldDecimal128, fieldDecimal128_len, true));
+      utility::SqlWcharToString(fieldDecimal128, fieldDecimal128_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDouble_len);
   BOOST_CHECK_EQUAL(1.7976931348623157e308, fieldDouble);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldString_len);
-  BOOST_CHECK_EQUAL("some Text", utility::SqlStringToString(
+  BOOST_CHECK_EQUAL("some Text", utility::SqlWcharToString(
                                      fieldString, fieldString_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldObjectId_len);
   BOOST_CHECK_EQUAL(
       "62196dcc4d9189219147513a",
-      utility::SqlStringToString(fieldObjectId, fieldObjectId_len, true));
+      utility::SqlWcharToString(fieldObjectId, fieldObjectId_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldBoolean_len);
   BOOST_CHECK_EQUAL(true, fieldBoolean);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDate_len);
@@ -489,10 +489,10 @@ BOOST_AUTO_TEST_CASE(TestSingleResultUsingBindCol) {
   BOOST_CHECK_EQUAL(9223372036854775807, fieldLong);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldMaxKey_len);
   BOOST_CHECK_EQUAL(
-      "MAXKEY", utility::SqlStringToString(fieldMaxKey, fieldMaxKey_len, true));
+      "MAXKEY", utility::SqlWcharToString(fieldMaxKey, fieldMaxKey_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldMinKey_len);
   BOOST_CHECK_EQUAL(
-      "MINKEY", utility::SqlStringToString(fieldMinKey, fieldMinKey_len, true));
+      "MINKEY", utility::SqlWcharToString(fieldMinKey, fieldMinKey_len, true));
   BOOST_CHECK_EQUAL(SQL_NULL_DATA, fieldNull_len);
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldBinary_len);
   BOOST_CHECK_EQUAL(3, fieldBinary_len);
@@ -537,11 +537,11 @@ BOOST_AUTO_TEST_CASE(TestMultiLineResultUsingGetData) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d91892191475139",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDecimal128_len);
   BOOST_CHECK_EQUAL(
       "340282350000000000000",
-      utility::SqlStringToString(fieldDecimal128, fieldDecimal128_len, true));
+      utility::SqlWcharToString(fieldDecimal128, fieldDecimal128_len, true));
 
   // Fetch 2nd row
   ret = SQLFetch(stmt);
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE(TestMultiLineResultUsingGetData) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d9189219147513a",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_EQUAL(SQL_NULL_DATA, fieldDecimal128_len);
 
   // Fetch 3rd row
@@ -568,11 +568,11 @@ BOOST_AUTO_TEST_CASE(TestMultiLineResultUsingGetData) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d9189219147513b",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldDecimal128_len);
   BOOST_CHECK_EQUAL(
       "340282350000000000000",
-      utility::SqlStringToString(fieldDecimal128, fieldDecimal128_len, true));
+      utility::SqlWcharToString(fieldDecimal128, fieldDecimal128_len, true));
 
   // Fetch 4th row - not exist
   ret = SQLFetch(stmt);
@@ -639,18 +639,18 @@ BOOST_AUTO_TEST_CASE(TestArrayStructJoinUsingGetData) {
   // Check the first row
   BOOST_CHECK_NE(SQL_NULL_DATA, id_len);
   BOOST_CHECK_EQUAL("62196dcc4d91892191475139",
-                    utility::SqlStringToString(id, id_len, true));
+                    utility::SqlWcharToString(id, id_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, a1_value_len);
   BOOST_CHECK_EQUAL(1, a1_value);
   BOOST_CHECK_NE(SQL_NULL_DATA, a2_value_len);
   BOOST_CHECK_EQUAL("value1",
-                    utility::SqlStringToString(a2_value, a2_value_len, true));
+                    utility::SqlWcharToString(a2_value, a2_value_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, d1_value_len);
   BOOST_CHECK_EQUAL("field1 Value",
-                    utility::SqlStringToString(d1_value, d1_value_len, true));
+                    utility::SqlWcharToString(d1_value, d1_value_len, true));
   BOOST_CHECK_NE(SQL_NULL_DATA, d2_value_len);
   BOOST_CHECK_EQUAL("field2 Value",
-                    utility::SqlStringToString(d2_value, d2_value_len, true));
+                    utility::SqlWcharToString(d2_value, d2_value_len, true));
 
   // Count the rows
   int32_t actual_rows = 0;
@@ -737,21 +737,21 @@ BOOST_AUTO_TEST_CASE(TestTwoRowsString, *disabled()) {
   if (!SQL_SUCCEEDED(ret))
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[0]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[1]), "2");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[2]), "3");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[3]), "4");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[4]), "5");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[5]), "6");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[6]), "7");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[7]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[8]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[0]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[1]), "2");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[2]), "3");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[3]), "4");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[4]), "5");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[5]), "6");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[6]), "7");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[7]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[8]),
                     "00000000-0000-0008-0000-000000000009");
   // Such format is used because Date returned as Timestamp.
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[9]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[9]),
                     "1987-06-05 00:00:00");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[10]), "12:48:12");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[11]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[10]), "12:48:12");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[11]),
                     "1998-12-27 01:02:03");
 
   SQLLEN columnLens[columnsCnt];
@@ -769,21 +769,21 @@ BOOST_AUTO_TEST_CASE(TestTwoRowsString, *disabled()) {
   if (!SQL_SUCCEEDED(ret))
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[0]), "8");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[1]), "7");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[2]), "6");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[3]), "5");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[4]), "4");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[5]), "3");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[6]), "2");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[7]), "0");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[8]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[0]), "8");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[1]), "7");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[2]), "6");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[3]), "5");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[4]), "4");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[5]), "3");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[6]), "2");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[7]), "0");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[8]),
                     "00000000-0000-0001-0000-000000000000");
   // Such format is used because Date returned as Timestamp.
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[9]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[9]),
                     "1976-01-12 00:00:00");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[10]), "00:08:59");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[11]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[10]), "00:08:59");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[11]),
                     "1978-08-21 23:13:45");
 
   BOOST_CHECK_EQUAL(columnLens[0], 1);
@@ -840,21 +840,21 @@ BOOST_AUTO_TEST_CASE(TestOneRowString, *disabled()) {
   if (!SQL_SUCCEEDED(ret))
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[0]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[1]), "2");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[2]), "3");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[3]), "4");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[4]), "5");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[5]), "6");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[6]), "7");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[7]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[8]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[0]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[1]), "2");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[2]), "3");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[3]), "4");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[4]), "5");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[5]), "6");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[6]), "7");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[7]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[8]),
                     "00000000-0000-0008-0000-000000000009");
   // Such format is used because Date returned as Timestamp.
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[9]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[9]),
                     "1987-06-05 00:00:00");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[10]), "12:48:12");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[11]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[10]), "12:48:12");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[11]),
                     "1998-12-27 01:02:03");
 
   BOOST_CHECK_EQUAL(columnLens[0], 1);
@@ -1079,21 +1079,21 @@ BOOST_AUTO_TEST_CASE(TestDataAtExecution, *disabled()) {
   if (!SQL_SUCCEEDED(ret))
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[0]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[1]), "2");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[2]), "3");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[3]), "4");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[4]), "5");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[5]), "6");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[6]), "7");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[7]), "1");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[8]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[0]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[1]), "2");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[2]), "3");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[3]), "4");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[4]), "5");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[5]), "6");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[6]), "7");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[7]), "1");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[8]),
                     "00000000-0000-0008-0000-000000000009");
   // Such format is used because Date returned as Timestamp.
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[9]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[9]),
                     "1987-06-05 00:00:00");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[10]), "12:48:12");
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(columns[11]),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[10]), "12:48:12");
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(columns[11]),
                     "1998-12-27 01:02:03");
 
   BOOST_CHECK_EQUAL(columnLens[0], 1);
@@ -1507,7 +1507,7 @@ BOOST_AUTO_TEST_CASE(TestExecuteAfterCursorClose, *disabled()) {
 
   BOOST_CHECK_EQUAL(key, 1);
 
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(strField, strFieldLen, true),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(strField, strFieldLen, true),
                     "5");
 
   ret = SQLFetch(stmt);
@@ -1556,7 +1556,7 @@ BOOST_AUTO_TEST_CASE(TestCloseNonFullFetch, *disabled()) {
     BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
 
   BOOST_CHECK_EQUAL(key, 1);
-  BOOST_CHECK_EQUAL(utility::SqlStringToString(strField, strFieldLen, true),
+  BOOST_CHECK_EQUAL(utility::SqlWcharToString(strField, strFieldLen, true),
                     "str1");
 
   ret = SQLFreeStmt(stmt, SQL_CLOSE);
@@ -2006,7 +2006,7 @@ BOOST_AUTO_TEST_CASE(TestSingleResultUsingGetDataWideChar) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldString_len);
   BOOST_CHECK_EQUAL(
-      u8"你好", utility::SqlStringToString(fieldString, fieldString_len, true));
+      u8"你好", utility::SqlWcharToString(fieldString, fieldString_len, true));
 
   // Fetch 2nd row - not exist
   ret = SQLFetch(stmt);
@@ -2041,7 +2041,7 @@ BOOST_AUTO_TEST_CASE(TestSingleResultSelectWideCharUsingGetDataWideChar) {
 
   BOOST_CHECK_NE(SQL_NULL_DATA, fieldString_len);
   BOOST_CHECK_EQUAL(
-      u8"你好", utility::SqlStringToString(fieldString, fieldString_len, true));
+      u8"你好", utility::SqlWcharToString(fieldString, fieldString_len, true));
 
   // Fetch 2nd row - does not exist
   ret = SQLFetch(stmt);

--- a/src/odbc-test/src/test_utils.cpp
+++ b/src/odbc-test/src/test_utils.cpp
@@ -40,8 +40,8 @@ OdbcClientError GetOdbcError(SQLSMALLINT handleType, SQLHANDLE handle) {
   SQLGetDiagRec(handleType, handle, 1, sqlstate, &nativeCode, message,
                 sizeof(message), &reallen);
 
-  return OdbcClientError(utility::SqlStringToString(sqlstate),
-                         utility::SqlStringToString(message));
+  return OdbcClientError(utility::SqlWcharToString(sqlstate),
+                         utility::SqlWcharToString(message));
 }
 
 std::string GetOdbcErrorState(SQLSMALLINT handleType, SQLHANDLE handle,
@@ -57,7 +57,7 @@ std::string GetOdbcErrorState(SQLSMALLINT handleType, SQLHANDLE handle,
   SQLGetDiagRec(handleType, handle, idx, sqlstate, &nativeCode, message,
                 sizeof(message), &reallen);
 
-  return utility::SqlStringToString(sqlstate);
+  return utility::SqlWcharToString(sqlstate);
 }
 
 std::string GetOdbcErrorMessage(SQLSMALLINT handleType, SQLHANDLE handle,
@@ -73,10 +73,10 @@ std::string GetOdbcErrorMessage(SQLSMALLINT handleType, SQLHANDLE handle,
   SQLGetDiagRec(handleType, handle, idx, sqlstate, &nativeCode, message,
                 sizeof(message), &reallen);
 
-  std::string res = utility::SqlStringToString(sqlstate);
+  std::string res = utility::SqlWcharToString(sqlstate);
 
   if (!res.empty()) {
-    res.append(": ").append(utility::SqlStringToString(message));
+    res.append(": ").append(utility::SqlWcharToString(message));
   } else {
     res = "No results";
   }

--- a/src/odbc-test/src/utility_test.cpp
+++ b/src/odbc-test/src/utility_test.cpp
@@ -49,39 +49,39 @@ BOOST_AUTO_TEST_CASE(TestUtilityCopyStringToBuffer) {
   buffer[0] = 0;
   bytesWrittenOrRequired =
       CopyStringToBuffer(str, buffer, sizeof(buffer) / sizeof(SQLWCHAR));
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), str);
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), str);
   BOOST_CHECK_EQUAL(wstr.size(), bytesWrittenOrRequired);
 
   // With length in byte mode
   buffer[0] = 0;
   bytesWrittenOrRequired =
       CopyStringToBuffer(str, buffer, sizeof(buffer), true);
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), str);
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), str);
   BOOST_CHECK_EQUAL(wstr.size() * sizeof(SQLWCHAR), bytesWrittenOrRequired);
 
   // 10 characters plus 1 for null char.
   buffer[0] = 0;
   bytesWrittenOrRequired = CopyStringToBuffer(str, buffer, 11, false);
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), ToUtf8(wstr.substr(0, 10)));
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), ToUtf8(wstr.substr(0, 10)));
   BOOST_CHECK_EQUAL(10, bytesWrittenOrRequired);
 
   // 10 characters plus 1 for null char, in bytes
   buffer[0] = 0;
   bytesWrittenOrRequired =
       CopyStringToBuffer(str, buffer, ((10 + 1) * sizeof(SQLWCHAR)), true);
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), ToUtf8(wstr.substr(0, 10)));
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), ToUtf8(wstr.substr(0, 10)));
   BOOST_CHECK_EQUAL(10 * sizeof(SQLWCHAR), bytesWrittenOrRequired);
 
   // Zero length buffer in character mode.
   buffer[0] = 0;
   bytesWrittenOrRequired = CopyStringToBuffer(str, buffer, 0);
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), std::string());
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), std::string());
   BOOST_CHECK_EQUAL(0, bytesWrittenOrRequired);
 
   // Zero length buffer in byte mode.
   buffer[0] = 0;
   bytesWrittenOrRequired = CopyStringToBuffer(str, buffer, 0, true);
-  BOOST_REQUIRE_EQUAL(SqlStringToString(buffer), std::string());
+  BOOST_REQUIRE_EQUAL(SqlWcharToString(buffer), std::string());
   BOOST_CHECK_EQUAL(0, bytesWrittenOrRequired);
 
   // nullptr buffer, zero length, in character mode.
@@ -136,35 +136,35 @@ BOOST_AUTO_TEST_CASE(TestUtilitySqlStringToString) {
   std::vector< SQLWCHAR > buffer = ToWCHARVector(utf8String);
   std::string utf8StringShortened = u8"你好 - Some da";
 
-  std::string result = SqlStringToString(buffer.data());
+  std::string result = SqlWcharToString(buffer.data());
   BOOST_CHECK_EQUAL(utf8String, result);
 
-  result = SqlStringToString(buffer.data(), buffer.size());
+  result = SqlWcharToString(buffer.data(), buffer.size());
   BOOST_CHECK_EQUAL(utf8String, result);
 
-  result = SqlStringToString(buffer.data(), buffer.size(), false);
+  result = SqlWcharToString(buffer.data(), buffer.size(), false);
   BOOST_CHECK_EQUAL(utf8String, result);
 
   result =
-      SqlStringToString(buffer.data(), buffer.size() * sizeof(SQLWCHAR), true);
+      SqlWcharToString(buffer.data(), buffer.size() * sizeof(SQLWCHAR), true);
   BOOST_CHECK_EQUAL(utf8String, result);
 
-  result = SqlStringToString(nullptr, buffer.size());
+  result = SqlWcharToString(nullptr, buffer.size());
   BOOST_CHECK_EQUAL(std::string(), result);
 
-  result = SqlStringToString(nullptr, buffer.size() * sizeof(SQLWCHAR), true);
+  result = SqlWcharToString(nullptr, buffer.size() * sizeof(SQLWCHAR), true);
   BOOST_CHECK_EQUAL(std::string(), result);
 
-  result = SqlStringToString(buffer.data(), 0);
+  result = SqlWcharToString(buffer.data(), 0);
   BOOST_CHECK_EQUAL(std::string(), result);
 
-  result = SqlStringToString(buffer.data(), 0, true);
+  result = SqlWcharToString(buffer.data(), 0, true);
   BOOST_CHECK_EQUAL(std::string(), result);
 
-  result = SqlStringToString(buffer.data(), 12);
+  result = SqlWcharToString(buffer.data(), 12);
   BOOST_CHECK_EQUAL(utf8StringShortened, result);
 
-  result = SqlStringToString(buffer.data(), 12 * sizeof(SQLWCHAR), true);
+  result = SqlWcharToString(buffer.data(), 12 * sizeof(SQLWCHAR), true);
   BOOST_CHECK_EQUAL(utf8StringShortened, result);
 }
 

--- a/src/odbc/include/ignite/odbc/utility.h
+++ b/src/odbc/include/ignite/odbc/utility.h
@@ -127,7 +127,7 @@ void ReadDecimal(BinaryReaderImpl& reader, Decimal& decimal);
 void WriteDecimal(BinaryWriterImpl& writer, const Decimal& decimal);
 
 /**
- * Convert SQL string buffer to std::string.
+ * Convert SQLWCHAR string buffer to std::string.
  *
  * @param sqlStr SQL string buffer.
  * @param sqlStrLen SQL string length.
@@ -135,12 +135,12 @@ void WriteDecimal(BinaryWriterImpl& writer, const Decimal& decimal);
  * characters.
  * @return Standard string containing the same data.
  */
-std::string SqlStringToString(const SQLWCHAR* sqlStr,
+std::string SqlWcharToString(const SQLWCHAR* sqlStr,
                               int32_t sqlStrLen = SQL_NTS,
                               bool isLenInBytes = false);
 
 /**
- * Convert SQL string buffer to boost::optional< std::string >.
+ * Convert SQLWCHAR string buffer to boost::optional< std::string >.
  *
  * @param sqlStr SQL string buffer.
  * @param sqlStrLen SQL string length.
@@ -149,9 +149,18 @@ std::string SqlStringToString(const SQLWCHAR* sqlStr,
  * @return Standard optional string containing the same data.
  * If sqlStrLen indicates null string, boost::none is returned.
  */
-boost::optional< std::string > SqlStringToOptString(const SQLWCHAR* sqlStr,
+boost::optional< std::string > SqlWcharToOptString(const SQLWCHAR* sqlStr,
                                                     int32_t sqlStrLen = SQL_NTS,
                                                     bool isLenInBytes = false);
+
+/**
+ * Convert SQL string buffer to std::string.
+ *
+ * @param sqlStr SQL string buffer.
+ * @param sqlStrLen SQL string length.
+ * @return Standard string containing the same data.
+ */
+std::string SqlCharToString(const SQLCHAR* sqlStr, int32_t sqlStrLen);
 
 /**
  * Convert a wide string to UTF-8 encoded string.

--- a/src/odbc/src/dsn_config.cpp
+++ b/src/odbc/src/dsn_config.cpp
@@ -40,7 +40,7 @@ void ThrowLastSetupError() {
   std::stringstream buf;
 
   buf << "Message: \""
-      << utility::SqlStringToString(msg.GetData(), msg.GetSize())
+      << utility::SqlWcharToString(msg.GetData(), msg.GetSize())
       << "\", Code: " << code;
 
   throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, buf.str().c_str());
@@ -77,7 +77,7 @@ SettableValue< std::string > ReadDsnString(const char* dsn,
         utility::ToWCHARVector(CONFIG_FILE).data());
   }
 
-  std::string res = utility::SqlStringToString(buf.GetData());
+  std::string res = utility::SqlWcharToString(buf.GetData());
 
   if (res != unique)
     val.SetValue(res);

--- a/src/odbc/src/odbc.cpp
+++ b/src/odbc/src/odbc.cpp
@@ -54,6 +54,8 @@ bool HandleParentWindow(SQLHWND windowHandle,
   return true;
 }
 
+using namespace ignite::odbc::utility;
+
 namespace ignite {
 SQLRETURN SQLGetInfo(SQLHDBC conn, SQLUSMALLINT infoType, SQLPOINTER infoValue,
                      SQLSMALLINT infoValueMax, SQLSMALLINT* length) {
@@ -322,7 +324,6 @@ SQLRETURN SQLDriverConnect(SQLHDBC conn, SQLHWND windowHandle,
   using odbc::Connection;
   using odbc::diagnostic::DiagnosticRecordStorage;
   using odbc::utility::CopyStringToBuffer;
-  using odbc::utility::SqlStringToString;
 
   LOG_DEBUG_MSG("SQLDriverConnect called");
 
@@ -342,7 +343,7 @@ SQLRETURN SQLDriverConnect(SQLHDBC conn, SQLHWND windowHandle,
   }
 
   std::string connectStr =
-      SqlStringToString(inConnectionString, inConnectionStringLen);
+      SqlWcharToString(inConnectionString, inConnectionStringLen);
   connection->Establish(connectStr, windowHandle);
 
   DiagnosticRecordStorage& diag = connection->GetDiagnosticRecords();
@@ -379,7 +380,6 @@ SQLRETURN SQLConnect(SQLHDBC conn, SQLWCHAR* serverName,
 
   using odbc::Connection;
   using odbc::config::Configuration;
-  using odbc::utility::SqlStringToString;
 
   LOG_DEBUG_MSG("SQLConnect called\n");
 
@@ -394,7 +394,7 @@ SQLRETURN SQLConnect(SQLHDBC conn, SQLWCHAR* serverName,
 
   odbc::config::Configuration config;
 
-  std::string dsn = SqlStringToString(serverName, serverNameLen);
+  std::string dsn = SqlWcharToString(serverName, serverNameLen);
 
   LOG_INFO_MSG("DSN: " << dsn);
 
@@ -431,7 +431,6 @@ SQLRETURN SQLDisconnect(SQLHDBC conn) {
 
 SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* query, SQLINTEGER queryLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToString;
 
   LOG_DEBUG_MSG("SQLPrepare called");
 
@@ -444,7 +443,7 @@ SQLRETURN SQLPrepare(SQLHSTMT stmt, SQLWCHAR* query, SQLINTEGER queryLen) {
     return SQL_INVALID_HANDLE;
   }
 
-  std::string sql = SqlStringToString(query, queryLen);
+  std::string sql = SqlWcharToString(query, queryLen);
 
   LOG_INFO_MSG("SQL: " << sql);
 
@@ -478,7 +477,6 @@ SQLRETURN SQLExecute(SQLHSTMT stmt) {
 
 SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* query, SQLINTEGER queryLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToString;
 
   LOG_DEBUG_MSG("SQLExecDirect called");
 
@@ -491,7 +489,7 @@ SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* query, SQLINTEGER queryLen) {
     return SQL_INVALID_HANDLE;
   }
 
-  std::string sql = SqlStringToString(query, queryLen);
+  std::string sql = SqlWcharToString(query, queryLen);
 
   LOG_INFO_MSG("SQL: " << sql);
 
@@ -632,7 +630,6 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLWCHAR* catalogName,
                     SQLSMALLINT tableNameLen, SQLWCHAR* tableType,
                     SQLSMALLINT tableTypeLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToOptString;
 
   LOG_DEBUG_MSG("SQLTables called");
 
@@ -646,13 +643,13 @@ SQLRETURN SQLTables(SQLHSTMT stmt, SQLWCHAR* catalogName,
   }
 
   boost::optional< std::string > catalog =
-      SqlStringToOptString(catalogName, catalogNameLen);
+      SqlWcharToOptString(catalogName, catalogNameLen);
   boost::optional< std::string > schema =
-      SqlStringToOptString(schemaName, schemaNameLen);
+      SqlWcharToOptString(schemaName, schemaNameLen);
   std::string table =
-      SqlStringToOptString(tableName, tableNameLen).get_value_or("%");
+      SqlWcharToOptString(tableName, tableNameLen).get_value_or("%");
   boost::optional< std::string > tableTypeStr =
-      SqlStringToOptString(tableType, tableTypeLen);
+      SqlWcharToOptString(tableType, tableTypeLen);
 
   LOG_INFO_MSG("catalog: " << catalog);
   LOG_INFO_MSG("schema: " << schema);
@@ -674,7 +671,6 @@ SQLRETURN SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalogName,
                      SQLSMALLINT tableNameLen, SQLWCHAR* columnName,
                      SQLSMALLINT columnNameLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToOptString;
 
   LOG_DEBUG_MSG("SQLColumns called");
 
@@ -688,13 +684,13 @@ SQLRETURN SQLColumns(SQLHSTMT stmt, SQLWCHAR* catalogName,
   }
 
   boost::optional< std::string > catalog =
-      SqlStringToOptString(catalogName, catalogNameLen);
+      SqlWcharToOptString(catalogName, catalogNameLen);
   boost::optional< std::string > schema =
-      SqlStringToOptString(schemaName, schemaNameLen);
+      SqlWcharToOptString(schemaName, schemaNameLen);
   std::string table =
-      SqlStringToOptString(tableName, tableNameLen).get_value_or("%");
+      SqlWcharToOptString(tableName, tableNameLen).get_value_or("%");
   std::string column =
-      SqlStringToOptString(columnName, columnNameLen).get_value_or("%");
+      SqlWcharToOptString(columnName, columnNameLen).get_value_or("%");
 
   LOG_INFO_MSG("catalog: " << catalog.get_value_or(""));
   LOG_INFO_MSG("schema: " << schema.get_value_or(""));
@@ -765,7 +761,7 @@ SQLRETURN SQLNativeSql(SQLHDBC conn, SQLWCHAR* inQuery, SQLINTEGER inQueryLen,
 
   LOG_DEBUG_MSG("SQLNativeSql called");
 
-  std::string in = SqlStringToString(inQuery, inQueryLen);
+  std::string in = SqlWcharToString(inQuery, inQueryLen);
 
   CopyStringToBuffer(in, outQueryBuffer,
                      static_cast< size_t >(outQueryBufferLen));
@@ -920,8 +916,6 @@ SQLRETURN SQLForeignKeys(
     SQLSMALLINT foreignSchemaNameLen, SQLWCHAR* foreignTableName,
     SQLSMALLINT foreignTableNameLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToOptString;
-  using odbc::utility::SqlStringToString;
 
   LOG_DEBUG_MSG("SQLForeignKeys called");
 
@@ -935,17 +929,17 @@ SQLRETURN SQLForeignKeys(
   }
 
   std::string primaryCatalog =
-      SqlStringToString(primaryCatalogName, primaryCatalogNameLen);
+      SqlWcharToString(primaryCatalogName, primaryCatalogNameLen);
   std::string primarySchema =
-      SqlStringToString(primarySchemaName, primarySchemaNameLen);
+      SqlWcharToString(primarySchemaName, primarySchemaNameLen);
   std::string primaryTable =
-      SqlStringToString(primaryTableName, primaryTableNameLen);
+      SqlWcharToString(primaryTableName, primaryTableNameLen);
   const boost::optional< std::string > foreignCatalog =
-      SqlStringToOptString(foreignCatalogName, foreignCatalogNameLen);
+      SqlWcharToOptString(foreignCatalogName, foreignCatalogNameLen);
   const boost::optional< std::string > foreignSchema =
-      SqlStringToOptString(foreignSchemaName, foreignSchemaNameLen);
+      SqlWcharToOptString(foreignSchemaName, foreignSchemaNameLen);
   std::string foreignTable =
-      SqlStringToString(foreignTableName, foreignTableNameLen);
+      SqlWcharToString(foreignTableName, foreignTableNameLen);
 
   LOG_INFO_MSG("primaryCatalog: " << primaryCatalog);
   LOG_INFO_MSG("primarySchema: " << primarySchema);
@@ -1026,7 +1020,6 @@ SQLRETURN SQLPrimaryKeys(SQLHSTMT stmt, SQLWCHAR* catalogName,
                          SQLSMALLINT schemaNameLen, SQLWCHAR* tableName,
                          SQLSMALLINT tableNameLen) {
   using odbc::Statement;
-  using odbc::utility::SqlStringToOptString;
 
   LOG_DEBUG_MSG("SQLPrimaryKeys called");
 
@@ -1040,11 +1033,11 @@ SQLRETURN SQLPrimaryKeys(SQLHSTMT stmt, SQLWCHAR* catalogName,
   }
 
   boost::optional< std::string > catalog =
-      SqlStringToOptString(catalogName, catalogNameLen);
+      SqlWcharToOptString(catalogName, catalogNameLen);
   boost::optional< std::string > schema =
-      SqlStringToOptString(schemaName, schemaNameLen);
+      SqlWcharToOptString(schemaName, schemaNameLen);
   boost::optional< std::string > table =
-      SqlStringToOptString(tableName, tableNameLen);
+      SqlWcharToOptString(tableName, tableNameLen);
 
   LOG_INFO_MSG("catalog: " << catalog.get_value_or(""));
   LOG_INFO_MSG("schema: " << schema.get_value_or(""));
@@ -1401,8 +1394,6 @@ SQLRETURN SQLSpecialColumns(SQLHSTMT stmt, SQLSMALLINT idType,
                             SQLSMALLINT scope, SQLSMALLINT nullable) {
   using namespace odbc;
 
-  using odbc::utility::SqlStringToString;
-
   LOG_DEBUG_MSG("SQLSpecialColumns called");
 
   Statement* statement = reinterpret_cast< Statement* >(stmt);
@@ -1414,9 +1405,9 @@ SQLRETURN SQLSpecialColumns(SQLHSTMT stmt, SQLSMALLINT idType,
     return SQL_INVALID_HANDLE;
   }
 
-  std::string catalog = SqlStringToString(catalogName, catalogNameLen);
-  std::string schema = SqlStringToString(schemaName, schemaNameLen);
-  std::string table = SqlStringToString(tableName, tableNameLen);
+  std::string catalog = SqlWcharToString(catalogName, catalogNameLen);
+  std::string schema = SqlWcharToString(schemaName, schemaNameLen);
+  std::string table = SqlWcharToString(tableName, tableNameLen);
 
   LOG_INFO_MSG("catalog: " << catalog);
   LOG_INFO_MSG("schema: " << schema);

--- a/src/odbc/src/utility.cpp
+++ b/src/odbc/src/utility.cpp
@@ -262,7 +262,7 @@ void WriteDecimal(BinaryWriterImpl& writer, const Decimal& decimal) {
                               magnitude.GetSize());
 }
 
-std::string SqlStringToString(const SQLWCHAR* sqlStr, int32_t sqlStrLen,
+std::string SqlWcharToString(const SQLWCHAR* sqlStr, int32_t sqlStrLen,
                               bool isLenInBytes) {
   if (!sqlStr)
     return std::string();
@@ -288,13 +288,29 @@ std::string SqlStringToString(const SQLWCHAR* sqlStr, int32_t sqlStrLen,
   return converter.to_bytes(sqlStr0);
 }
 
-boost::optional< std::string > SqlStringToOptString(const SQLWCHAR* sqlStr,
+boost::optional< std::string > SqlWcharToOptString(const SQLWCHAR* sqlStr,
                                                     int32_t sqlStrLen,
                                                     bool isLenInBytes) {
   if (!sqlStr)
     return boost::none;
 
-  return SqlStringToString(sqlStr, sqlStrLen, isLenInBytes);
+  return SqlWcharToString(sqlStr, sqlStrLen, isLenInBytes);
+}
+
+std::string SqlCharToString(const SQLCHAR* sqlStr, int32_t sqlStrLen) {
+  std::string res;
+
+  const char* sqlStrC = reinterpret_cast< const char* >(sqlStr);
+
+  if (!sqlStr || !sqlStrLen)
+    return res;
+
+  if (sqlStrLen == SQL_NTS)
+    res.assign(sqlStrC);
+  else if (sqlStrLen > 0)
+    res.assign(sqlStrC, sqlStrLen);
+
+  return res;
 }
 
 std::string ToUtf8(const std::wstring& value) {


### PR DESCRIPTION
### Summary

[AD-803] Do not create debug log artifacts if build successful.
[AD-811] Correct conversion errors between different data types and SQLWCHAR

### Description

[AD-803] Do not create debug log artifacts if build successful.
[AD-811] Correct conversion errors between different data types and SQLWCHAR

### Related Issue

https://bitquill.atlassian.net/browse/AD-803
https://bitquill.atlassian.net/browse/AD-811


### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->
