### PR TITLE
[AD-909] Correct SQL state returned when trying to set SQL_ATTR_ROW_ARRAY_SIZE.

### DIFF
--- a/src/odbc/src/statement.cpp
+++ b/src/odbc/src/statement.cpp
@@ -232,7 +232,7 @@ SqlResult::Type Statement::InternalSetAttribute(int attr, void* value,
 
       if (val != 1) {
         AddStatusRecord(
-            SqlState::SIM001_FUNCTION_NOT_SUPPORTED,
+            SqlState::S01S02_OPTION_VALUE_CHANGED,
             "Array size value cannot be set to a value other than 1");
 
         return SqlResult::AI_ERROR;


### PR DESCRIPTION
### Summary

[AD-909] Correct SQL state returned when trying to set SQL_ATTR_ROW_ARRAY_SIZE.

### Description

Corrects SQL state returned when trying to set SQL_ATTR_ROW_ARRAY_SIZE.

### Related Issue

https://bitquill.atlassian.net/browse/AD-909

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->
