### PR TITLE
[AD-552] Implement SQLGetTypeInfo return type info.

### DIFF
--- a/src/odbc-test/src/column_meta_test.cpp
+++ b/src/odbc-test/src/column_meta_test.cpp
@@ -100,12 +100,12 @@ BOOST_AUTO_TEST_CASE(TestGetAttribute) {
   // test SQL_DESC_TYPE_NAME
   found = columnMeta.GetAttribute(SQL_DESC_TYPE_NAME, resVal);
   BOOST_CHECK(found);
-  BOOST_CHECK_EQUAL(resVal, SqlTypeName::VARCHAR);
+  BOOST_CHECK_EQUAL(resVal, SqlTypeName::NVARCHAR);
 
   // test SQL_DESC_LOCAL_TYPE_NAME
   found = columnMeta.GetAttribute(SQL_DESC_LOCAL_TYPE_NAME, resVal);
   BOOST_CHECK(found);
-  BOOST_CHECK_EQUAL(resVal, SqlTypeName::VARCHAR);
+  BOOST_CHECK_EQUAL(resVal, SqlTypeName::NVARCHAR);
 
   // fields SQL_COLUMN_PRECISION and SQL_DESC_SCALE are not tested
   // for retrieving string values
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(TestGetAttributeLocalTypeName) {
       std::make_pair(JDBC_TYPE_FLOAT, SqlTypeName::FLOAT),
       std::make_pair(JDBC_TYPE_REAL, SqlTypeName::REAL),
       std::make_pair(JDBC_TYPE_DOUBLE, SqlTypeName::DOUBLE),
-      std::make_pair(JDBC_TYPE_VARCHAR, SqlTypeName::VARCHAR),
+      std::make_pair(JDBC_TYPE_VARCHAR, SqlTypeName::NVARCHAR),
       std::make_pair(JDBC_TYPE_BINARY, SqlTypeName::BINARY),
       std::make_pair(JDBC_TYPE_VARBINARY, SqlTypeName::VARBINARY),
       std::make_pair(JDBC_TYPE_DATE, SqlTypeName::DATE),

--- a/src/odbc/include/documentdb/odbc/jni/database_metadata.h
+++ b/src/odbc/include/documentdb/odbc/jni/database_metadata.h
@@ -86,6 +86,11 @@ class DatabaseMetaData {
       const boost::optional< std::string >& schema, const std::string& table,
       JniErrorInfo& errInfo);
 
+  /**
+   * Query the type info in the database.
+   */
+  SharedPointer< ResultSet > GetTypeInfo(JniErrorInfo& errInfo);
+
  private:
   /**
    * Constructs an instance of the DatabaseMetaData class.

--- a/src/odbc/include/documentdb/odbc/jni/java.h
+++ b/src/odbc/include/documentdb/odbc/jni/java.h
@@ -290,6 +290,7 @@ struct JniMembers {
   jmethodID m_DatabaseMetaDataGetColumns;
   jmethodID m_DatabaseMetaDataGetPrimaryKeys;
   jmethodID m_DatabaseMetaDataGetImportedKeys;
+  jmethodID m_DatabaseMetaDataGetTypeInfo;
 
   jclass c_List;
   jmethodID m_ListSize;
@@ -558,6 +559,10 @@ class DOCUMENTDB_IMPORT_EXPORT JniContext {
       const SharedPointer< GlobalJObject >& databaseMetaData,
       const boost::optional< std::string >& catalog,
       const boost::optional< std::string >& schema, const std::string& table,
+      SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo);
+
+  JniErrorCode DatabaseMetaDataGetTypeInfo(
+      const SharedPointer< GlobalJObject >& databaseMetaData,
       SharedPointer< GlobalJObject >& resultSet, JniErrorInfo& errInfo);
 
   JniErrorCode ResultSetClose(const SharedPointer< GlobalJObject >& resultSet,

--- a/src/odbc/include/documentdb/odbc/query/type_info_query.h
+++ b/src/odbc/include/documentdb/odbc/query/type_info_query.h
@@ -19,6 +19,7 @@
 #define _DOCUMENTDB_ODBC_QUERY_TYPE_INFO_QUERY
 
 #include "documentdb/odbc/query/query.h"
+#include <set>
 
 namespace documentdb {
 namespace odbc {
@@ -32,9 +33,10 @@ class TypeInfoQuery : public Query {
    * Constructor.
    *
    * @param diag Diagnostics collector.
+   * @param connection open connection.
    * @param sqlType SQL type.
    */
-  TypeInfoQuery(diagnostic::DiagnosableAdapter& diag, int16_t sqlType);
+  TypeInfoQuery(diagnostic::DiagnosableAdapter& diag, Connection& connection, int16_t sqlType);
 
   /**
    * Destructor.
@@ -103,6 +105,17 @@ class TypeInfoQuery : public Query {
  private:
   DOCUMENTDB_NO_COPY_ASSIGNMENT(TypeInfoQuery);
 
+  /** 
+   * Makes request via the JNI interface and builds the types.
+   */
+  SqlResult::Type MakeRequestGetTypeInfo();
+
+  /** Connection. */
+  Connection& connection;
+
+  /** Requested SQL type(s) */
+  int16_t requestedSqlType;
+
   /** Columns metadata. */
   meta::ColumnMetaVector columnsMeta;
 
@@ -112,11 +125,14 @@ class TypeInfoQuery : public Query {
   /** Fetched flag. */
   bool fetched;
 
-  /** Requested types. */
-  std::vector< int8_t > types;
+  /** Supported binary types. */
+  std::set< int16_t > binaryTypes;
+
+  /** Supported SQL types. */
+  std::set< int16_t > sqlTypes;
 
   /** Query cursor. */
-  std::vector< int8_t >::const_iterator cursor;
+  std::set< int16_t >::const_iterator cursor;
 };
 }  // namespace query
 }  // namespace odbc

--- a/src/odbc/include/documentdb/odbc/type_traits.h
+++ b/src/odbc/include/documentdb/odbc/type_traits.h
@@ -144,11 +144,14 @@ class SqlTypeName {
   /** BIGINT SQL type name constant. */
   static const std::string BIGINT;
 
-  /** VARCHAR SQL type name constant. */
-  static const std::string VARCHAR;
+  /** NCHAR SQL type name constant. */
+  static const std::string NCHAR;
 
-  /** LONGVARCHAR SQL type name constant. */
-  static const std::string LONGVARCHAR;
+  /** NVARCHAR SQL type name constant. */
+  static const std::string NVARCHAR;
+
+  /** LONGNVARCHAR SQL type name constant. */
+  static const std::string LONGNVARCHAR;
 
   /** BINARY SQL type name constant. */
   static const std::string BINARY;

--- a/src/odbc/src/jni/database_metadata.cpp
+++ b/src/odbc/src/jni/database_metadata.cpp
@@ -89,6 +89,18 @@ SharedPointer< ResultSet > DatabaseMetaData::GetImportedKeys(
   }
   return new ResultSet(_jniContext, resultSet);
 }
+
+SharedPointer< ResultSet > DatabaseMetaData::GetTypeInfo(
+    JniErrorInfo& errInfo) {
+  SharedPointer< GlobalJObject > resultSet;
+  const std::vector< std::string > types;
+  JniErrorCode success = _jniContext.Get()->DatabaseMetaDataGetTypeInfo(
+      _databaseMetaData, resultSet, errInfo);
+  if (success != JniErrorCode::DOCUMENTDB_JNI_ERR_SUCCESS) {
+    return nullptr;
+  }
+  return new ResultSet(_jniContext, resultSet);
+}
 }  // namespace jni
 }  // namespace odbc
 }  // namespace documentdb

--- a/src/odbc/src/statement.cpp
+++ b/src/odbc/src/statement.cpp
@@ -798,7 +798,7 @@ SqlResult::Type Statement::InternalExecuteGetTypeInfoQuery(int16_t sqlType) {
   if (currentQuery.get())
     currentQuery->Close();
 
-  currentQuery.reset(new query::TypeInfoQuery(*this, sqlType));
+  currentQuery.reset(new query::TypeInfoQuery(*this, connection, sqlType));
 
   return currentQuery->Execute();
 }

--- a/src/odbc/src/type_traits.cpp
+++ b/src/odbc/src/type_traits.cpp
@@ -46,9 +46,11 @@ const std::string SqlTypeName::TINYINT("TINYINT");
 
 const std::string SqlTypeName::BIGINT("BIGINT");
 
-const std::string SqlTypeName::VARCHAR("VARCHAR");
+const std::string SqlTypeName::NCHAR("NCHAR");
 
-const std::string SqlTypeName::LONGVARCHAR("LONGVARCHAR");
+const std::string SqlTypeName::NVARCHAR("NVARCHAR");
+
+const std::string SqlTypeName::LONGNVARCHAR("LONGNVARCHAR");
 
 const std::string SqlTypeName::BINARY("BINARY");
 
@@ -155,13 +157,17 @@ const boost::optional< std::string > BinaryTypeToSqlTypeName(
     case JDBC_TYPE_DECIMAL:
       return SqlTypeName::DECIMAL;
 
+    case JDBC_TYPE_CHAR:
+    case JDBC_TYPE_NCHAR:
+      return SqlTypeName::NCHAR;
+
     case JDBC_TYPE_VARCHAR:
     case JDBC_TYPE_NVARCHAR:
-      return SqlTypeName::VARCHAR;
+      return SqlTypeName::NVARCHAR;
 
     case JDBC_TYPE_LONGVARCHAR:
     case JDBC_TYPE_LONGNVARCHAR:
-      return SqlTypeName::LONGVARCHAR;
+      return SqlTypeName::LONGNVARCHAR;
 
     case JDBC_TYPE_DATE:
       return SqlTypeName::DATE;
@@ -488,7 +494,7 @@ boost::optional< int16_t > BinaryToSqlType(
 }
 
 int16_t BinaryTypeNullability(int16_t) {
-  return SQL_NULLABLE_UNKNOWN;
+  return SQL_NULLABLE;
 }
 
 boost::optional< std::string > NullabilityToIsNullable(
@@ -790,6 +796,8 @@ bool SqlTypeUnsigned(boost::optional< int16_t > type) {
     case SQL_REAL:
     case SQL_FLOAT:
     case SQL_DOUBLE:
+    case SQL_DECIMAL:
+    case SQL_NUMERIC:
       return false;
 
     default:


### PR DESCRIPTION
### Summary

[AD-552] Implement SQLGetTypeInfo return type info.

### Description

- [x] Call `GetTypeInfo` using JNI interface
- [x] Modify `SQLGetTypeInfo` to handle returned values consistently
- [x] Add unit tests for JNI call.
- [x] Add integration for `SQLGetTypeInfo`.

### Related Issue

https://bitquill.atlassian.net/browse/AD-552

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->
