### PR TITLE
[AD-958] [ODBC] Correct ACAT scan issue(s)

### DIFF
--- a/src/odbc/src/common/utils.cpp
+++ b/src/odbc/src/common/utils.cpp
@@ -57,7 +57,7 @@ char* CopyChars(const char* val) {
   if (val) {
     size_t len = strlen(val);
     char* dest = new char[len + 1];
-    strcpy(dest, val);
+    strncpy(dest, val, len);
     *(dest + len) = 0;
     return dest;
   }


### PR DESCRIPTION
### Summary

[AD-958] [ODBC] Correct ACAT scan issue(s)

### Description

Removed strcpy and replaced with strncpy

### Related Issue

https://bitquill.atlassian.net/browse/AD-958

### Additional Reviewers
@affonsoBQ
@alexey-temnikov
@alinaliBQ
@andiem-bq
@birschick-bq
@mitchell-elholm
@RoyZhang2022
<!-- Any additional reviewers -->
